### PR TITLE
API Support for specifying the statistics file path

### DIFF
--- a/ab/nn/api.py
+++ b/ab/nn/api.py
@@ -23,10 +23,10 @@ def data(only_best_accuracy=False, task=None, dataset=None, metric=None, nn=None
     dt: tuple[dict, ...] = DB_Read.data(only_best_accuracy, task=task, dataset=dataset, metric=metric, nn=nn, epoch=epoch, cast_prm=cast_prm)
     return DataFrame.from_records(dt)
 
-def check_nn(nn_code : str, task : str, dataset : str, metric : str, prm: dict, save_to_db=True, prefix = None) -> tuple[str, float, int]:
+def check_nn(nn_code : str, task : str, dataset : str, metric : str, prm: dict, save_to_db=True, prefix = None, save_path = None) -> tuple[str, float, int]:
     """
     Train the new NN model with the provided hyperparameters (prm) and save it to the database if training is successful.
     for argument description see :ref:`ab.nn.util.db.Write.save_nn()`
     :return: Automatically generated name of NN model and its accuracy.
     """
-    return Train.train_new(nn_code, task, dataset, metric, prm, save_to_db=save_to_db, prefix = prefix)
+    return Train.train_new(nn_code, task, dataset, metric, prm, save_to_db=save_to_db, prefix = prefix, save_path = save_path)

--- a/ab/nn/util/Train.py
+++ b/ab/nn/util/Train.py
@@ -229,7 +229,7 @@ def train_new(nn_code, task, dataset, metric, prm, save_to_db=True, prefix:Union
     if prefix is None:
         name = None
     else:
-        prefix + "-" + DB_Write.uuid4() # Create temporal name for processing
+        name = prefix + "-" + DB_Write.uuid4() # Create temporal name for processing
     spec = importlib.util.find_spec("ab.nn.tmp")
     dir_path = os.path.dirname(spec.origin)
     with tempfile.NamedTemporaryFile(mode='w+', suffix='.py', delete=True, dir=dir_path) as temp_file:

--- a/ab/nn/util/Train.py
+++ b/ab/nn/util/Train.py
@@ -172,6 +172,9 @@ class Train:
             accuracy = self.eval(self.test_loader)
             accuracy = 0.0 if math.isnan(accuracy) or math.isinf(accuracy) else accuracy
             duration = time.time_ns() - start_time
+            ## TODO : Accuracy_to_time_metric is calculated and returned from here, 
+            # BUT in the Database is the accuracy WITHOUT considering time.
+            # Please fix this logic if it's a issue. (Maybe it's meant to have such behaviour?)
             accuracy_to_time = accuracy_to_time_metric(accuracy, self.minimum_accuracy, duration)
             if not good(accuracy, self.minimum_accuracy, duration):
                 raise AccuracyException(accuracy_to_time,

--- a/ab/nn/util/Train.py
+++ b/ab/nn/util/Train.py
@@ -184,11 +184,11 @@ class Train:
                     if self.save_path is None:
                         print(f"[WARN]parameter `save_Path` set to null, the staticis will not be saved into a file.")
                     else:
-                        save_results(self.config + (epoch,), self.save_path, prm)
+                        save_results(self.config + (epoch,), join(self.save_path, f"{epoch}.json"), prm)
                 else: # Legacy save result codes in file
                     if self.save_path is None:
-                        self.save_path = join(model_stat_dir(self.config), f"{epoch}.json")
-                    save_results(self.config + (epoch,), self.save_path, prm)
+                        self.save_path = model_stat_dir(self.config)
+                    save_results(self.config + (epoch,), join(self.save_path, f"{epoch}.json"), prm)
                     DB_Write.save_results(self.config + (epoch,), prm) # Separated from Calc.save_results()
         return accuracy_to_time, duration
 
@@ -211,7 +211,7 @@ class Train:
         return self.metric_function.result()
 
 
-def train_new(nn_code, task, dataset, metric, prm, save_to_db=True, prefix:Union[str,None] = None, save_path = None):
+def train_new(nn_code, task, dataset, metric, prm, save_to_db=True, prefix:Union[str,None] = None, save_path:Union[str,None] = None):
     """
     train the model with the given code and hyperparameters and evaluate it.
 
@@ -221,7 +221,8 @@ def train_new(nn_code, task, dataset, metric, prm, save_to_db=True, prefix:Union
         dataset (str): Name of the dataset
         metric (str): Evaluation metric
         prm (dict): Hyperparameters, e.g., 'lr', 'momentum', 'batch', 'epoch', 'dropout'
-        prefix():
+        prefix (str|None): Prefix of the model, set to None if is unknown.
+        save_path (str|None): Path to save the statistics, or None to not save. 
     return:
         (str, float): Name of the model and the accuracy
     """

--- a/ab/nn/util/Train.py
+++ b/ab/nn/util/Train.py
@@ -98,6 +98,8 @@ class Train:
         :param test_dataset: Dataset used for evaluating/testing the model (e.g., torch.utils.data.Dataset).
         :param metric: Name of the evaluation metric (e.g., 'acc', 'iou').
         :param prm: Dictionary of hyperparameters and their values (e.g., {'lr': 0.11, 'momentum': 0.2})
+        :param is_code: Whether `config.model` is `nn_code` or `nn`
+        :param save_path: Path to save the statistics, set to `None` to use the default
         """
         self.config = config
         self.train_dataset = train_dataset
@@ -209,7 +211,7 @@ class Train:
         return self.metric_function.result()
 
 
-def train_new(nn_code, task, dataset, metric, prm, save_to_db=True, prefix = None, save_path = None):
+def train_new(nn_code, task, dataset, metric, prm, save_to_db=True, prefix:Union[str,None] = None, save_path = None):
     """
     train the model with the given code and hyperparameters and evaluate it.
 
@@ -219,6 +221,7 @@ def train_new(nn_code, task, dataset, metric, prm, save_to_db=True, prefix = Non
         dataset (str): Name of the dataset
         metric (str): Evaluation metric
         prm (dict): Hyperparameters, e.g., 'lr', 'momentum', 'batch', 'epoch', 'dropout'
+        prefix():
     return:
         (str, float): Name of the model and the accuracy
     """

--- a/ab/nn/util/db/Calc.py
+++ b/ab/nn/util/db/Calc.py
@@ -35,4 +35,3 @@ def save_results(config_ext: tuple[str, str, str, str, int], model_stat_file: st
         json.dump(trials_dict_all, f, indent=4)
 
     print(f"Trial (accuracy {prm['accuracy']}) for ({', '.join([str(o) for o in config_ext])}) saved at {model_stat_file}")
-    DB_Write.save_results(config_ext, prm)

--- a/ab/nn/util/db/Write.py
+++ b/ab/nn/util/db/Write.py
@@ -15,14 +15,14 @@ def init_population():
         json_n_code_to_db()
 
 
-def code_to_db(cursor, table_name, code=None, code_file=None, prefix = None):
+def code_to_db(cursor, table_name, code=None, code_file=None, force_name = None):
     # If model does not exist, insert it with a new UUID
     if code_file:
         nm = code_file.stem 
-    elif prefix is None:
+    elif force_name is None:
         nm = uuid4()
     else:
-        nm = prefix + "-" + uuid4() # Save in format `<prefix>-<uuid>`
+        nm = force_name
     if not code:
         with open(code_file, 'r') as file:
             code = file.read()
@@ -112,9 +112,9 @@ def save_results(config_ext: tuple[str, str, str, str, int], prm: dict):
     close_conn(conn)
 
 
-def save_nn(nn_code: str, task: str, dataset: str, metric: str, epoch: int, prm: dict, prefix = None):
+def save_nn(nn_code: str, task: str, dataset: str, metric: str, epoch: int, prm: dict, force_name = None):
     conn, cursor = sql_conn()
-    nn = code_to_db(cursor, 'nn', code=nn_code, prefix=prefix)
+    nn = code_to_db(cursor, 'nn', code=nn_code, force_name=force_name)
     save_stat((task, dataset, metric, nn, epoch), prm, cursor)
     close_conn(conn)
     return nn


### PR DESCRIPTION
Added a parameter to specify the statistics file path.
Thus the statistics file can also be created and stored when passing `nn_code` to the `Trainer`.

***Attention***: In `Trainer.train_n_eval()` the `accuracy_to_time` is returned and be used as final accuracy of the evaluated codes in `train_new()` in the original logics. However, in original `Trainer.train_n_eval()`, when only model name is passed in, the `DB_Write.save_results` stores the accuracy that doesn't consider the time, please check if this is a typo, or is meant to be saved "as it".