### PR TITLE
Fix pip install detection to include user-level site-packages and loader table error for user-level pip installs

### DIFF
--- a/ab/nn/util/db/Util.py
+++ b/ab/nn/util/db/Util.py
@@ -37,7 +37,10 @@ def get_package_location(package_name) -> Optional[Path]:
 def check_if_script_is_pip_installed() -> bool:
     script_location = os.path.abspath(__file__)
     site_packages_dirs = site.getsitepackages()
-
+    try:
+        site_packages_dirs = site_packages_dirs + [site.getusersitepackages()]
+    except Exception:
+        pass
     for site_package in site_packages_dirs:
         if site_package in script_location:
             return True


### PR DESCRIPTION
When nn-dataset is installed as a non-root user (pip install --user), site.getsitepackages() does not include the user site-packages path (~/.local/lib/python3.x/site-packages). This caused check_if_script_is_pip_installed() to return False, so nn_mod() used the wrong root path and triggered:

    sqlite3.OperationalError: no such table: loader

Fix: also check site.getusersitepackages(), wrapped in try/except for environments where it is unavailable.