### PR TITLE
fix: Set valid=false and strip duration fields for all-zero benchmark runs

### DIFF
--- a/ab/nn/stat/run/tflite/fp32/img-classification_cifar-10_acc_unq-e1c6d812a3eb56cf7a120830088fad7a/android_STK-L21.json
+++ b/ab/nn/stat/run/tflite/fp32/img-classification_cifar-10_acc_unq-e1c6d812a3eb56cf7a120830088fad7a/android_STK-L21.json
@@ -2,23 +2,9 @@
   "model_name": "unq-e1c6d812a3eb56cf7a120830088fad7a",
   "device_type": "STK-L21",
   "os_version": "10 | HUAWEISTK-L21",
-  "valid": true,
+  "valid": false,
   "emulator": false,
   "iterations": 20,
-  "duration": 0,
-  "unit": "Failed",
-  "cpu_duration": 0,
-  "cpu_min_duration": 0,
-  "cpu_max_duration": 0,
-  "cpu_std_dev": 0,
-  "gpu_duration": 0,
-  "gpu_min_duration": 0,
-  "gpu_max_duration": 0,
-  "gpu_std_dev": 0,
-  "npu_duration": 0,
-  "npu_min_duration": 0,
-  "npu_max_duration": 0,
-  "npu_std_dev": 0,
   "in_dim_0": 1,
   "in_dim_1": 3,
   "in_dim_2": 3,
@@ -38,7 +24,5 @@
         "cpu_revision": ""
       }
     }
-  },
-  "npu_error": "timeout or failed",
-  "gpu_error": "timeout or failed"
+  }
 }

--- a/ab/nn/stat/run/tflite/fp32/img-classification_cifar-10_acc_unq-e273123056fb7b373e10474352e3a475/android_STK-L21.json
+++ b/ab/nn/stat/run/tflite/fp32/img-classification_cifar-10_acc_unq-e273123056fb7b373e10474352e3a475/android_STK-L21.json
@@ -2,23 +2,9 @@
   "model_name": "unq-e273123056fb7b373e10474352e3a475",
   "device_type": "STK-L21",
   "os_version": "10 | HUAWEISTK-L21",
-  "valid": true,
+  "valid": false,
   "emulator": false,
   "iterations": 20,
-  "duration": 0,
-  "unit": "Failed",
-  "cpu_duration": 0,
-  "cpu_min_duration": 0,
-  "cpu_max_duration": 0,
-  "cpu_std_dev": 0,
-  "gpu_duration": 0,
-  "gpu_min_duration": 0,
-  "gpu_max_duration": 0,
-  "gpu_std_dev": 0,
-  "npu_duration": 0,
-  "npu_min_duration": 0,
-  "npu_max_duration": 0,
-  "npu_std_dev": 0,
   "in_dim_0": 1,
   "in_dim_1": 64,
   "in_dim_2": 64,
@@ -38,7 +24,5 @@
         "cpu_revision": ""
       }
     }
-  },
-  "npu_error": "timeout or failed",
-  "gpu_error": "timeout or failed"
+  }
 }

--- a/ab/nn/stat/run/tflite/fp32/img-classification_cifar-10_acc_unq-e3728da7bcd5f8199ea16c9439847e8f/android_STK-L21.json
+++ b/ab/nn/stat/run/tflite/fp32/img-classification_cifar-10_acc_unq-e3728da7bcd5f8199ea16c9439847e8f/android_STK-L21.json
@@ -2,23 +2,9 @@
   "model_name": "unq-e3728da7bcd5f8199ea16c9439847e8f",
   "device_type": "STK-L21",
   "os_version": "10 | HUAWEISTK-L21",
-  "valid": true,
+  "valid": false,
   "emulator": false,
   "iterations": 20,
-  "duration": 0,
-  "unit": "Failed",
-  "cpu_duration": 0,
-  "cpu_min_duration": 0,
-  "cpu_max_duration": 0,
-  "cpu_std_dev": 0,
-  "gpu_duration": 0,
-  "gpu_min_duration": 0,
-  "gpu_max_duration": 0,
-  "gpu_std_dev": 0,
-  "npu_duration": 0,
-  "npu_min_duration": 0,
-  "npu_max_duration": 0,
-  "npu_std_dev": 0,
   "in_dim_0": 1,
   "in_dim_1": 64,
   "in_dim_2": 64,
@@ -38,7 +24,5 @@
         "cpu_revision": ""
       }
     }
-  },
-  "npu_error": "timeout or failed",
-  "gpu_error": "timeout or failed"
+  }
 }

--- a/ab/nn/stat/run/tflite/fp32/img-classification_cifar-10_acc_unq-e379e94250005861fb8816daa9c5b0d8/android_STK-L21.json
+++ b/ab/nn/stat/run/tflite/fp32/img-classification_cifar-10_acc_unq-e379e94250005861fb8816daa9c5b0d8/android_STK-L21.json
@@ -2,23 +2,9 @@
   "model_name": "unq-e379e94250005861fb8816daa9c5b0d8",
   "device_type": "STK-L21",
   "os_version": "10 | HUAWEISTK-L21",
-  "valid": true,
+  "valid": false,
   "emulator": false,
   "iterations": 20,
-  "duration": 0,
-  "unit": "Failed",
-  "cpu_duration": 0,
-  "cpu_min_duration": 0,
-  "cpu_max_duration": 0,
-  "cpu_std_dev": 0,
-  "gpu_duration": 0,
-  "gpu_min_duration": 0,
-  "gpu_max_duration": 0,
-  "gpu_std_dev": 0,
-  "npu_duration": 0,
-  "npu_min_duration": 0,
-  "npu_max_duration": 0,
-  "npu_std_dev": 0,
   "in_dim_0": 1,
   "in_dim_1": 64,
   "in_dim_2": 64,
@@ -38,7 +24,5 @@
         "cpu_revision": ""
       }
     }
-  },
-  "npu_error": "timeout or failed",
-  "gpu_error": "timeout or failed"
+  }
 }

--- a/ab/nn/stat/run/tflite/fp32/img-classification_cifar-10_acc_unq-e3aec622909575e3f83b28220a34da3f/android_STK-L21.json
+++ b/ab/nn/stat/run/tflite/fp32/img-classification_cifar-10_acc_unq-e3aec622909575e3f83b28220a34da3f/android_STK-L21.json
@@ -2,23 +2,9 @@
   "model_name": "unq-e3aec622909575e3f83b28220a34da3f",
   "device_type": "STK-L21",
   "os_version": "10 | HUAWEISTK-L21",
-  "valid": true,
+  "valid": false,
   "emulator": false,
   "iterations": 20,
-  "duration": 0,
-  "unit": "Failed",
-  "cpu_duration": 0,
-  "cpu_min_duration": 0,
-  "cpu_max_duration": 0,
-  "cpu_std_dev": 0,
-  "gpu_duration": 0,
-  "gpu_min_duration": 0,
-  "gpu_max_duration": 0,
-  "gpu_std_dev": 0,
-  "npu_duration": 0,
-  "npu_min_duration": 0,
-  "npu_max_duration": 0,
-  "npu_std_dev": 0,
   "in_dim_0": 1,
   "in_dim_1": 64,
   "in_dim_2": 64,
@@ -38,7 +24,5 @@
         "cpu_revision": ""
       }
     }
-  },
-  "npu_error": "timeout or failed",
-  "gpu_error": "timeout or failed"
+  }
 }

--- a/ab/nn/stat/run/tflite/fp32/img-classification_cifar-10_acc_unq-e3d674bb2ddc2a203ae9e18092097b24/android_STK-L21.json
+++ b/ab/nn/stat/run/tflite/fp32/img-classification_cifar-10_acc_unq-e3d674bb2ddc2a203ae9e18092097b24/android_STK-L21.json
@@ -2,23 +2,9 @@
   "model_name": "unq-e3d674bb2ddc2a203ae9e18092097b24",
   "device_type": "STK-L21",
   "os_version": "10 | HUAWEISTK-L21",
-  "valid": true,
+  "valid": false,
   "emulator": false,
   "iterations": 20,
-  "duration": 0,
-  "unit": "Failed",
-  "cpu_duration": 0,
-  "cpu_min_duration": 0,
-  "cpu_max_duration": 0,
-  "cpu_std_dev": 0,
-  "gpu_duration": 0,
-  "gpu_min_duration": 0,
-  "gpu_max_duration": 0,
-  "gpu_std_dev": 0,
-  "npu_duration": 0,
-  "npu_min_duration": 0,
-  "npu_max_duration": 0,
-  "npu_std_dev": 0,
   "in_dim_0": 1,
   "in_dim_1": 31,
   "in_dim_2": 31,
@@ -38,7 +24,5 @@
         "cpu_revision": ""
       }
     }
-  },
-  "npu_error": "timeout or failed",
-  "gpu_error": "timeout or failed"
+  }
 }

--- a/ab/nn/stat/run/tflite/fp32/img-classification_cifar-10_acc_unq-e3fbb5272ddcb9c30f6782f3d2c6b015/android_STK-L21.json
+++ b/ab/nn/stat/run/tflite/fp32/img-classification_cifar-10_acc_unq-e3fbb5272ddcb9c30f6782f3d2c6b015/android_STK-L21.json
@@ -2,23 +2,9 @@
   "model_name": "unq-e3fbb5272ddcb9c30f6782f3d2c6b015",
   "device_type": "STK-L21",
   "os_version": "10 | HUAWEISTK-L21",
-  "valid": true,
+  "valid": false,
   "emulator": false,
   "iterations": 20,
-  "duration": 0,
-  "unit": "Failed",
-  "cpu_duration": 0,
-  "cpu_min_duration": 0,
-  "cpu_max_duration": 0,
-  "cpu_std_dev": 0,
-  "gpu_duration": 0,
-  "gpu_min_duration": 0,
-  "gpu_max_duration": 0,
-  "gpu_std_dev": 0,
-  "npu_duration": 0,
-  "npu_min_duration": 0,
-  "npu_max_duration": 0,
-  "npu_std_dev": 0,
   "in_dim_0": 1,
   "in_dim_1": 64,
   "in_dim_2": 64,
@@ -38,7 +24,5 @@
         "cpu_revision": ""
       }
     }
-  },
-  "npu_error": "timeout or failed",
-  "gpu_error": "timeout or failed"
+  }
 }

--- a/ab/nn/stat/run/tflite/fp32/img-classification_cifar-10_acc_unq-e3fbebacee71560dedd5007ca6a38c49/android_STK-L21.json
+++ b/ab/nn/stat/run/tflite/fp32/img-classification_cifar-10_acc_unq-e3fbebacee71560dedd5007ca6a38c49/android_STK-L21.json
@@ -2,23 +2,9 @@
   "model_name": "unq-e3fbebacee71560dedd5007ca6a38c49",
   "device_type": "STK-L21",
   "os_version": "10 | HUAWEISTK-L21",
-  "valid": true,
+  "valid": false,
   "emulator": false,
   "iterations": 20,
-  "duration": 0,
-  "unit": "Failed",
-  "cpu_duration": 0,
-  "cpu_min_duration": 0,
-  "cpu_max_duration": 0,
-  "cpu_std_dev": 0,
-  "gpu_duration": 0,
-  "gpu_min_duration": 0,
-  "gpu_max_duration": 0,
-  "gpu_std_dev": 0,
-  "npu_duration": 0,
-  "npu_min_duration": 0,
-  "npu_max_duration": 0,
-  "npu_std_dev": 0,
   "in_dim_0": 1,
   "in_dim_1": 64,
   "in_dim_2": 64,
@@ -38,7 +24,5 @@
         "cpu_revision": ""
       }
     }
-  },
-  "npu_error": "timeout or failed",
-  "gpu_error": "timeout or failed"
+  }
 }

--- a/ab/nn/stat/run/tflite/fp32/img-classification_cifar-10_acc_unq-e44ae24011ab6ce02881cea9e1fd8422/android_STK-L21.json
+++ b/ab/nn/stat/run/tflite/fp32/img-classification_cifar-10_acc_unq-e44ae24011ab6ce02881cea9e1fd8422/android_STK-L21.json
@@ -2,23 +2,9 @@
   "model_name": "unq-e44ae24011ab6ce02881cea9e1fd8422",
   "device_type": "STK-L21",
   "os_version": "10 | HUAWEISTK-L21",
-  "valid": true,
+  "valid": false,
   "emulator": false,
   "iterations": 20,
-  "duration": 0,
-  "unit": "Failed",
-  "cpu_duration": 0,
-  "cpu_min_duration": 0,
-  "cpu_max_duration": 0,
-  "cpu_std_dev": 0,
-  "gpu_duration": 0,
-  "gpu_min_duration": 0,
-  "gpu_max_duration": 0,
-  "gpu_std_dev": 0,
-  "npu_duration": 0,
-  "npu_min_duration": 0,
-  "npu_max_duration": 0,
-  "npu_std_dev": 0,
   "in_dim_0": 1,
   "in_dim_1": 30,
   "in_dim_2": 30,
@@ -38,7 +24,5 @@
         "cpu_revision": ""
       }
     }
-  },
-  "npu_error": "timeout or failed",
-  "gpu_error": "timeout or failed"
+  }
 }

--- a/ab/nn/stat/run/tflite/fp32/img-classification_cifar-10_acc_unq-e44cb7a653488f81e2ae6af25c16231e/android_STK-L21.json
+++ b/ab/nn/stat/run/tflite/fp32/img-classification_cifar-10_acc_unq-e44cb7a653488f81e2ae6af25c16231e/android_STK-L21.json
@@ -2,23 +2,9 @@
   "model_name": "unq-e44cb7a653488f81e2ae6af25c16231e",
   "device_type": "STK-L21",
   "os_version": "10 | HUAWEISTK-L21",
-  "valid": true,
+  "valid": false,
   "emulator": false,
   "iterations": 20,
-  "duration": 0,
-  "unit": "Failed",
-  "cpu_duration": 0,
-  "cpu_min_duration": 0,
-  "cpu_max_duration": 0,
-  "cpu_std_dev": 0,
-  "gpu_duration": 0,
-  "gpu_min_duration": 0,
-  "gpu_max_duration": 0,
-  "gpu_std_dev": 0,
-  "npu_duration": 0,
-  "npu_min_duration": 0,
-  "npu_max_duration": 0,
-  "npu_std_dev": 0,
   "in_dim_0": 1,
   "in_dim_1": 64,
   "in_dim_2": 64,
@@ -38,7 +24,5 @@
         "cpu_revision": ""
       }
     }
-  },
-  "npu_error": "timeout or failed",
-  "gpu_error": "timeout or failed"
+  }
 }

--- a/ab/nn/stat/run/tflite/fp32/img-classification_cifar-10_acc_unq-e48d0591ef09fcec6a45fc75dc4602eb/android_STK-L21.json
+++ b/ab/nn/stat/run/tflite/fp32/img-classification_cifar-10_acc_unq-e48d0591ef09fcec6a45fc75dc4602eb/android_STK-L21.json
@@ -2,23 +2,9 @@
   "model_name": "unq-e48d0591ef09fcec6a45fc75dc4602eb",
   "device_type": "STK-L21",
   "os_version": "10 | HUAWEISTK-L21",
-  "valid": true,
+  "valid": false,
   "emulator": false,
   "iterations": 20,
-  "duration": 0,
-  "unit": "Failed",
-  "cpu_duration": 0,
-  "cpu_min_duration": 0,
-  "cpu_max_duration": 0,
-  "cpu_std_dev": 0,
-  "gpu_duration": 0,
-  "gpu_min_duration": 0,
-  "gpu_max_duration": 0,
-  "gpu_std_dev": 0,
-  "npu_duration": 0,
-  "npu_min_duration": 0,
-  "npu_max_duration": 0,
-  "npu_std_dev": 0,
   "in_dim_0": 1,
   "in_dim_1": 64,
   "in_dim_2": 64,
@@ -38,7 +24,5 @@
         "cpu_revision": ""
       }
     }
-  },
-  "npu_error": "timeout or failed",
-  "gpu_error": "timeout or failed"
+  }
 }

--- a/ab/nn/stat/run/tflite/fp32/img-classification_cifar-10_acc_unq-e5616457b750b03b15c6ac0b19f9f738/android_STK-L21.json
+++ b/ab/nn/stat/run/tflite/fp32/img-classification_cifar-10_acc_unq-e5616457b750b03b15c6ac0b19f9f738/android_STK-L21.json
@@ -2,23 +2,9 @@
   "model_name": "unq-e5616457b750b03b15c6ac0b19f9f738",
   "device_type": "STK-L21",
   "os_version": "10 | HUAWEISTK-L21",
-  "valid": true,
+  "valid": false,
   "emulator": false,
   "iterations": 20,
-  "duration": 0,
-  "unit": "Failed",
-  "cpu_duration": 0,
-  "cpu_min_duration": 0,
-  "cpu_max_duration": 0,
-  "cpu_std_dev": 0,
-  "gpu_duration": 0,
-  "gpu_min_duration": 0,
-  "gpu_max_duration": 0,
-  "gpu_std_dev": 0,
-  "npu_duration": 0,
-  "npu_min_duration": 0,
-  "npu_max_duration": 0,
-  "npu_std_dev": 0,
   "in_dim_0": 1,
   "in_dim_1": 128,
   "in_dim_2": 128,
@@ -38,7 +24,5 @@
         "cpu_revision": ""
       }
     }
-  },
-  "npu_error": "timeout or failed",
-  "gpu_error": "timeout or failed"
+  }
 }

--- a/ab/nn/stat/run/tflite/fp32/img-classification_cifar-10_acc_unq-e63f8eda71470d27626a3a3374a67313/android_STK-L21.json
+++ b/ab/nn/stat/run/tflite/fp32/img-classification_cifar-10_acc_unq-e63f8eda71470d27626a3a3374a67313/android_STK-L21.json
@@ -2,23 +2,9 @@
   "model_name": "unq-e63f8eda71470d27626a3a3374a67313",
   "device_type": "STK-L21",
   "os_version": "10 | HUAWEISTK-L21",
-  "valid": true,
+  "valid": false,
   "emulator": false,
   "iterations": 20,
-  "duration": 0,
-  "unit": "Failed",
-  "cpu_duration": 0,
-  "cpu_min_duration": 0,
-  "cpu_max_duration": 0,
-  "cpu_std_dev": 0,
-  "gpu_duration": 0,
-  "gpu_min_duration": 0,
-  "gpu_max_duration": 0,
-  "gpu_std_dev": 0,
-  "npu_duration": 0,
-  "npu_min_duration": 0,
-  "npu_max_duration": 0,
-  "npu_std_dev": 0,
   "in_dim_0": 1,
   "in_dim_1": 30,
   "in_dim_2": 30,
@@ -38,7 +24,5 @@
         "cpu_revision": ""
       }
     }
-  },
-  "npu_error": "timeout or failed",
-  "gpu_error": "timeout or failed"
+  }
 }

--- a/ab/nn/stat/run/tflite/fp32/img-classification_cifar-10_acc_unq-e829307b85fbe806e9603e92db40432c/android_STK-L21.json
+++ b/ab/nn/stat/run/tflite/fp32/img-classification_cifar-10_acc_unq-e829307b85fbe806e9603e92db40432c/android_STK-L21.json
@@ -2,23 +2,9 @@
   "model_name": "unq-e829307b85fbe806e9603e92db40432c",
   "device_type": "STK-L21",
   "os_version": "10 | HUAWEISTK-L21",
-  "valid": true,
+  "valid": false,
   "emulator": false,
   "iterations": 20,
-  "duration": 0,
-  "unit": "Failed",
-  "cpu_duration": 0,
-  "cpu_min_duration": 0,
-  "cpu_max_duration": 0,
-  "cpu_std_dev": 0,
-  "gpu_duration": 0,
-  "gpu_min_duration": 0,
-  "gpu_max_duration": 0,
-  "gpu_std_dev": 0,
-  "npu_duration": 0,
-  "npu_min_duration": 0,
-  "npu_max_duration": 0,
-  "npu_std_dev": 0,
   "in_dim_0": 1,
   "in_dim_1": 256,
   "in_dim_2": 256,
@@ -38,7 +24,5 @@
         "cpu_revision": ""
       }
     }
-  },
-  "npu_error": "timeout or failed",
-  "gpu_error": "timeout or failed"
+  }
 }

--- a/ab/nn/stat/run/tflite/fp32/img-classification_cifar-10_acc_unq-e8c8ffb22b408e6e21d148cb223d9f4a/android_STK-L21.json
+++ b/ab/nn/stat/run/tflite/fp32/img-classification_cifar-10_acc_unq-e8c8ffb22b408e6e21d148cb223d9f4a/android_STK-L21.json
@@ -2,23 +2,9 @@
   "model_name": "unq-e8c8ffb22b408e6e21d148cb223d9f4a",
   "device_type": "STK-L21",
   "os_version": "10 | HUAWEISTK-L21",
-  "valid": true,
+  "valid": false,
   "emulator": false,
   "iterations": 20,
-  "duration": 0,
-  "unit": "Failed",
-  "cpu_duration": 0,
-  "cpu_min_duration": 0,
-  "cpu_max_duration": 0,
-  "cpu_std_dev": 0,
-  "gpu_duration": 0,
-  "gpu_min_duration": 0,
-  "gpu_max_duration": 0,
-  "gpu_std_dev": 0,
-  "npu_duration": 0,
-  "npu_min_duration": 0,
-  "npu_max_duration": 0,
-  "npu_std_dev": 0,
   "in_dim_0": 1,
   "in_dim_1": 32,
   "in_dim_2": 32,
@@ -38,7 +24,5 @@
         "cpu_revision": ""
       }
     }
-  },
-  "npu_error": "timeout or failed",
-  "gpu_error": "timeout or failed"
+  }
 }

--- a/ab/nn/stat/run/tflite/fp32/img-classification_cifar-10_acc_unq-e928c5cf875eddf85c767433f1e5b49d/android_STK-L21.json
+++ b/ab/nn/stat/run/tflite/fp32/img-classification_cifar-10_acc_unq-e928c5cf875eddf85c767433f1e5b49d/android_STK-L21.json
@@ -2,23 +2,9 @@
   "model_name": "unq-e928c5cf875eddf85c767433f1e5b49d",
   "device_type": "STK-L21",
   "os_version": "10 | HUAWEISTK-L21",
-  "valid": true,
+  "valid": false,
   "emulator": false,
   "iterations": 20,
-  "duration": 0,
-  "unit": "Failed",
-  "cpu_duration": 0,
-  "cpu_min_duration": 0,
-  "cpu_max_duration": 0,
-  "cpu_std_dev": 0,
-  "gpu_duration": 0,
-  "gpu_min_duration": 0,
-  "gpu_max_duration": 0,
-  "gpu_std_dev": 0,
-  "npu_duration": 0,
-  "npu_min_duration": 0,
-  "npu_max_duration": 0,
-  "npu_std_dev": 0,
   "in_dim_0": 1,
   "in_dim_1": 64,
   "in_dim_2": 64,
@@ -38,7 +24,5 @@
         "cpu_revision": ""
       }
     }
-  },
-  "npu_error": "timeout or failed",
-  "gpu_error": "timeout or failed"
+  }
 }

--- a/ab/nn/stat/run/tflite/fp32/img-classification_cifar-10_acc_unq-e94b07fc7608be5f53894e9d68be1fed/android_STK-L21.json
+++ b/ab/nn/stat/run/tflite/fp32/img-classification_cifar-10_acc_unq-e94b07fc7608be5f53894e9d68be1fed/android_STK-L21.json
@@ -2,23 +2,9 @@
   "model_name": "unq-e94b07fc7608be5f53894e9d68be1fed",
   "device_type": "STK-L21",
   "os_version": "10 | HUAWEISTK-L21",
-  "valid": true,
+  "valid": false,
   "emulator": false,
   "iterations": 20,
-  "duration": 0,
-  "unit": "Failed",
-  "cpu_duration": 0,
-  "cpu_min_duration": 0,
-  "cpu_max_duration": 0,
-  "cpu_std_dev": 0,
-  "gpu_duration": 0,
-  "gpu_min_duration": 0,
-  "gpu_max_duration": 0,
-  "gpu_std_dev": 0,
-  "npu_duration": 0,
-  "npu_min_duration": 0,
-  "npu_max_duration": 0,
-  "npu_std_dev": 0,
   "in_dim_0": 1,
   "in_dim_1": 64,
   "in_dim_2": 64,
@@ -38,7 +24,5 @@
         "cpu_revision": ""
       }
     }
-  },
-  "npu_error": "timeout or failed",
-  "gpu_error": "timeout or failed"
+  }
 }

--- a/ab/nn/stat/run/tflite/fp32/img-classification_cifar-10_acc_unq-e95137bd067ae892db35f40987867f54/android_STK-L21.json
+++ b/ab/nn/stat/run/tflite/fp32/img-classification_cifar-10_acc_unq-e95137bd067ae892db35f40987867f54/android_STK-L21.json
@@ -2,23 +2,9 @@
   "model_name": "unq-e95137bd067ae892db35f40987867f54",
   "device_type": "STK-L21",
   "os_version": "10 | HUAWEISTK-L21",
-  "valid": true,
+  "valid": false,
   "emulator": false,
   "iterations": 20,
-  "duration": 0,
-  "unit": "Failed",
-  "cpu_duration": 0,
-  "cpu_min_duration": 0,
-  "cpu_max_duration": 0,
-  "cpu_std_dev": 0,
-  "gpu_duration": 0,
-  "gpu_min_duration": 0,
-  "gpu_max_duration": 0,
-  "gpu_std_dev": 0,
-  "npu_duration": 0,
-  "npu_min_duration": 0,
-  "npu_max_duration": 0,
-  "npu_std_dev": 0,
   "in_dim_0": 1,
   "in_dim_1": 30,
   "in_dim_2": 30,
@@ -38,7 +24,5 @@
         "cpu_revision": ""
       }
     }
-  },
-  "npu_error": "timeout or failed",
-  "gpu_error": "timeout or failed"
+  }
 }

--- a/ab/nn/stat/run/tflite/fp32/img-classification_cifar-10_acc_unq-e985a3423c752050b8dd9c0f3c5bfa83/android_STK-L21.json
+++ b/ab/nn/stat/run/tflite/fp32/img-classification_cifar-10_acc_unq-e985a3423c752050b8dd9c0f3c5bfa83/android_STK-L21.json
@@ -2,23 +2,9 @@
   "model_name": "unq-e985a3423c752050b8dd9c0f3c5bfa83",
   "device_type": "STK-L21",
   "os_version": "10 | HUAWEISTK-L21",
-  "valid": true,
+  "valid": false,
   "emulator": false,
   "iterations": 20,
-  "duration": 0,
-  "unit": "Failed",
-  "cpu_duration": 0,
-  "cpu_min_duration": 0,
-  "cpu_max_duration": 0,
-  "cpu_std_dev": 0,
-  "gpu_duration": 0,
-  "gpu_min_duration": 0,
-  "gpu_max_duration": 0,
-  "gpu_std_dev": 0,
-  "npu_duration": 0,
-  "npu_min_duration": 0,
-  "npu_max_duration": 0,
-  "npu_std_dev": 0,
   "in_dim_0": 1,
   "in_dim_1": 64,
   "in_dim_2": 64,
@@ -38,7 +24,5 @@
         "cpu_revision": ""
       }
     }
-  },
-  "npu_error": "timeout or failed",
-  "gpu_error": "timeout or failed"
+  }
 }

--- a/ab/nn/stat/run/tflite/fp32/img-classification_cifar-10_acc_unq-e99c5fdfcdaa135744e90e186feabd49/android_STK-L21.json
+++ b/ab/nn/stat/run/tflite/fp32/img-classification_cifar-10_acc_unq-e99c5fdfcdaa135744e90e186feabd49/android_STK-L21.json
@@ -2,23 +2,9 @@
   "model_name": "unq-e99c5fdfcdaa135744e90e186feabd49",
   "device_type": "STK-L21",
   "os_version": "10 | HUAWEISTK-L21",
-  "valid": true,
+  "valid": false,
   "emulator": false,
   "iterations": 20,
-  "duration": 0,
-  "unit": "Failed",
-  "cpu_duration": 0,
-  "cpu_min_duration": 0,
-  "cpu_max_duration": 0,
-  "cpu_std_dev": 0,
-  "gpu_duration": 0,
-  "gpu_min_duration": 0,
-  "gpu_max_duration": 0,
-  "gpu_std_dev": 0,
-  "npu_duration": 0,
-  "npu_min_duration": 0,
-  "npu_max_duration": 0,
-  "npu_std_dev": 0,
   "in_dim_0": 1,
   "in_dim_1": 64,
   "in_dim_2": 64,
@@ -38,7 +24,5 @@
         "cpu_revision": ""
       }
     }
-  },
-  "npu_error": "timeout or failed",
-  "gpu_error": "timeout or failed"
+  }
 }

--- a/ab/nn/stat/run/tflite/fp32/img-classification_cifar-10_acc_unq-e9b8a760cdc7bbf108354d00d8b5e53f/android_STK-L21.json
+++ b/ab/nn/stat/run/tflite/fp32/img-classification_cifar-10_acc_unq-e9b8a760cdc7bbf108354d00d8b5e53f/android_STK-L21.json
@@ -2,23 +2,9 @@
   "model_name": "unq-e9b8a760cdc7bbf108354d00d8b5e53f",
   "device_type": "STK-L21",
   "os_version": "10 | HUAWEISTK-L21",
-  "valid": true,
+  "valid": false,
   "emulator": false,
   "iterations": 20,
-  "duration": 0,
-  "unit": "Failed",
-  "cpu_duration": 0,
-  "cpu_min_duration": 0,
-  "cpu_max_duration": 0,
-  "cpu_std_dev": 0,
-  "gpu_duration": 0,
-  "gpu_min_duration": 0,
-  "gpu_max_duration": 0,
-  "gpu_std_dev": 0,
-  "npu_duration": 0,
-  "npu_min_duration": 0,
-  "npu_max_duration": 0,
-  "npu_std_dev": 0,
   "in_dim_0": 1,
   "in_dim_1": 64,
   "in_dim_2": 64,
@@ -38,7 +24,5 @@
         "cpu_revision": ""
       }
     }
-  },
-  "npu_error": "timeout or failed",
-  "gpu_error": "timeout or failed"
+  }
 }

--- a/ab/nn/stat/run/tflite/fp32/img-classification_cifar-10_acc_unq-e9d1204a1321e7fc0932595590293890/android_STK-L21.json
+++ b/ab/nn/stat/run/tflite/fp32/img-classification_cifar-10_acc_unq-e9d1204a1321e7fc0932595590293890/android_STK-L21.json
@@ -2,23 +2,9 @@
   "model_name": "unq-e9d1204a1321e7fc0932595590293890",
   "device_type": "STK-L21",
   "os_version": "10 | HUAWEISTK-L21",
-  "valid": true,
+  "valid": false,
   "emulator": false,
   "iterations": 20,
-  "duration": 0,
-  "unit": "Failed",
-  "cpu_duration": 0,
-  "cpu_min_duration": 0,
-  "cpu_max_duration": 0,
-  "cpu_std_dev": 0,
-  "gpu_duration": 0,
-  "gpu_min_duration": 0,
-  "gpu_max_duration": 0,
-  "gpu_std_dev": 0,
-  "npu_duration": 0,
-  "npu_min_duration": 0,
-  "npu_max_duration": 0,
-  "npu_std_dev": 0,
   "in_dim_0": 1,
   "in_dim_1": 64,
   "in_dim_2": 64,
@@ -38,7 +24,5 @@
         "cpu_revision": ""
       }
     }
-  },
-  "npu_error": "timeout or failed",
-  "gpu_error": "timeout or failed"
+  }
 }

--- a/ab/nn/stat/run/tflite/fp32/img-classification_cifar-10_acc_unq-e9f0c45f824764dbd8b4f93309a56919/android_STK-L21.json
+++ b/ab/nn/stat/run/tflite/fp32/img-classification_cifar-10_acc_unq-e9f0c45f824764dbd8b4f93309a56919/android_STK-L21.json
@@ -2,23 +2,9 @@
   "model_name": "unq-e9f0c45f824764dbd8b4f93309a56919",
   "device_type": "STK-L21",
   "os_version": "10 | HUAWEISTK-L21",
-  "valid": true,
+  "valid": false,
   "emulator": false,
   "iterations": 20,
-  "duration": 0,
-  "unit": "Failed",
-  "cpu_duration": 0,
-  "cpu_min_duration": 0,
-  "cpu_max_duration": 0,
-  "cpu_std_dev": 0,
-  "gpu_duration": 0,
-  "gpu_min_duration": 0,
-  "gpu_max_duration": 0,
-  "gpu_std_dev": 0,
-  "npu_duration": 0,
-  "npu_min_duration": 0,
-  "npu_max_duration": 0,
-  "npu_std_dev": 0,
   "in_dim_0": 1,
   "in_dim_1": 32,
   "in_dim_2": 32,
@@ -38,7 +24,5 @@
         "cpu_revision": ""
       }
     }
-  },
-  "npu_error": "timeout or failed",
-  "gpu_error": "timeout or failed"
+  }
 }

--- a/ab/nn/stat/run/tflite/fp32/img-classification_cifar-10_acc_unq-e9fecd5d808ceed2dbcc66099c0e8274/android_STK-L21.json
+++ b/ab/nn/stat/run/tflite/fp32/img-classification_cifar-10_acc_unq-e9fecd5d808ceed2dbcc66099c0e8274/android_STK-L21.json
@@ -2,23 +2,9 @@
   "model_name": "unq-e9fecd5d808ceed2dbcc66099c0e8274",
   "device_type": "STK-L21",
   "os_version": "10 | HUAWEISTK-L21",
-  "valid": true,
+  "valid": false,
   "emulator": false,
   "iterations": 20,
-  "duration": 0,
-  "unit": "Failed",
-  "cpu_duration": 0,
-  "cpu_min_duration": 0,
-  "cpu_max_duration": 0,
-  "cpu_std_dev": 0,
-  "gpu_duration": 0,
-  "gpu_min_duration": 0,
-  "gpu_max_duration": 0,
-  "gpu_std_dev": 0,
-  "npu_duration": 0,
-  "npu_min_duration": 0,
-  "npu_max_duration": 0,
-  "npu_std_dev": 0,
   "in_dim_0": 1,
   "in_dim_1": 31,
   "in_dim_2": 31,
@@ -38,7 +24,5 @@
         "cpu_revision": ""
       }
     }
-  },
-  "npu_error": "timeout or failed",
-  "gpu_error": "timeout or failed"
+  }
 }

--- a/ab/nn/stat/run/tflite/fp32/img-classification_cifar-10_acc_unq-ea2167b1d42214588e0d39e11500cd42/android_STK-L21.json
+++ b/ab/nn/stat/run/tflite/fp32/img-classification_cifar-10_acc_unq-ea2167b1d42214588e0d39e11500cd42/android_STK-L21.json
@@ -2,23 +2,9 @@
   "model_name": "unq-ea2167b1d42214588e0d39e11500cd42",
   "device_type": "STK-L21",
   "os_version": "10 | HUAWEISTK-L21",
-  "valid": true,
+  "valid": false,
   "emulator": false,
   "iterations": 20,
-  "duration": 0,
-  "unit": "Failed",
-  "cpu_duration": 0,
-  "cpu_min_duration": 0,
-  "cpu_max_duration": 0,
-  "cpu_std_dev": 0,
-  "gpu_duration": 0,
-  "gpu_min_duration": 0,
-  "gpu_max_duration": 0,
-  "gpu_std_dev": 0,
-  "npu_duration": 0,
-  "npu_min_duration": 0,
-  "npu_max_duration": 0,
-  "npu_std_dev": 0,
   "in_dim_0": 1,
   "in_dim_1": 32,
   "in_dim_2": 32,
@@ -38,7 +24,5 @@
         "cpu_revision": ""
       }
     }
-  },
-  "npu_error": "timeout or failed",
-  "gpu_error": "timeout or failed"
+  }
 }

--- a/ab/nn/stat/run/tflite/fp32/img-classification_cifar-10_acc_unq-ea2d2e370a93b7097fe37b0dada88430/android_STK-L21.json
+++ b/ab/nn/stat/run/tflite/fp32/img-classification_cifar-10_acc_unq-ea2d2e370a93b7097fe37b0dada88430/android_STK-L21.json
@@ -2,23 +2,9 @@
   "model_name": "unq-ea2d2e370a93b7097fe37b0dada88430",
   "device_type": "STK-L21",
   "os_version": "10 | HUAWEISTK-L21",
-  "valid": true,
+  "valid": false,
   "emulator": false,
   "iterations": 20,
-  "duration": 0,
-  "unit": "Failed",
-  "cpu_duration": 0,
-  "cpu_min_duration": 0,
-  "cpu_max_duration": 0,
-  "cpu_std_dev": 0,
-  "gpu_duration": 0,
-  "gpu_min_duration": 0,
-  "gpu_max_duration": 0,
-  "gpu_std_dev": 0,
-  "npu_duration": 0,
-  "npu_min_duration": 0,
-  "npu_max_duration": 0,
-  "npu_std_dev": 0,
   "in_dim_0": 1,
   "in_dim_1": 28,
   "in_dim_2": 28,
@@ -38,7 +24,5 @@
         "cpu_revision": ""
       }
     }
-  },
-  "npu_error": "timeout or failed",
-  "gpu_error": "timeout or failed"
+  }
 }

--- a/ab/nn/stat/run/tflite/fp32/img-classification_cifar-10_acc_unq-ebf99f2b6fa529f179b1c8907540e675/android_STK-L21.json
+++ b/ab/nn/stat/run/tflite/fp32/img-classification_cifar-10_acc_unq-ebf99f2b6fa529f179b1c8907540e675/android_STK-L21.json
@@ -2,23 +2,9 @@
   "model_name": "unq-ebf99f2b6fa529f179b1c8907540e675",
   "device_type": "STK-L21",
   "os_version": "10 | HUAWEISTK-L21",
-  "valid": true,
+  "valid": false,
   "emulator": false,
   "iterations": 20,
-  "duration": 0,
-  "unit": "Failed",
-  "cpu_duration": 0,
-  "cpu_min_duration": 0,
-  "cpu_max_duration": 0,
-  "cpu_std_dev": 0,
-  "gpu_duration": 0,
-  "gpu_min_duration": 0,
-  "gpu_max_duration": 0,
-  "gpu_std_dev": 0,
-  "npu_duration": 0,
-  "npu_min_duration": 0,
-  "npu_max_duration": 0,
-  "npu_std_dev": 0,
   "in_dim_0": 1,
   "in_dim_1": 30,
   "in_dim_2": 30,
@@ -38,7 +24,5 @@
         "cpu_revision": ""
       }
     }
-  },
-  "npu_error": "timeout or failed",
-  "gpu_error": "timeout or failed"
+  }
 }

--- a/ab/nn/stat/run/tflite/fp32/img-classification_cifar-10_acc_unq-ec47f92c22dc21e4b4c00c93503264d0/android_STK-L21.json
+++ b/ab/nn/stat/run/tflite/fp32/img-classification_cifar-10_acc_unq-ec47f92c22dc21e4b4c00c93503264d0/android_STK-L21.json
@@ -2,23 +2,9 @@
   "model_name": "unq-ec47f92c22dc21e4b4c00c93503264d0",
   "device_type": "STK-L21",
   "os_version": "10 | HUAWEISTK-L21",
-  "valid": true,
+  "valid": false,
   "emulator": false,
   "iterations": 20,
-  "duration": 0,
-  "unit": "Failed",
-  "cpu_duration": 0,
-  "cpu_min_duration": 0,
-  "cpu_max_duration": 0,
-  "cpu_std_dev": 0,
-  "gpu_duration": 0,
-  "gpu_min_duration": 0,
-  "gpu_max_duration": 0,
-  "gpu_std_dev": 0,
-  "npu_duration": 0,
-  "npu_min_duration": 0,
-  "npu_max_duration": 0,
-  "npu_std_dev": 0,
   "in_dim_0": 1,
   "in_dim_1": 32,
   "in_dim_2": 32,
@@ -38,7 +24,5 @@
         "cpu_revision": ""
       }
     }
-  },
-  "npu_error": "timeout or failed",
-  "gpu_error": "timeout or failed"
+  }
 }

--- a/ab/nn/stat/run/tflite/fp32/img-classification_cifar-10_acc_unq-ecad43cb32155d3235c9b87cba581811/android_STK-L21.json
+++ b/ab/nn/stat/run/tflite/fp32/img-classification_cifar-10_acc_unq-ecad43cb32155d3235c9b87cba581811/android_STK-L21.json
@@ -2,23 +2,9 @@
   "model_name": "unq-ecad43cb32155d3235c9b87cba581811",
   "device_type": "STK-L21",
   "os_version": "10 | HUAWEISTK-L21",
-  "valid": true,
+  "valid": false,
   "emulator": false,
   "iterations": 20,
-  "duration": 0,
-  "unit": "Failed",
-  "cpu_duration": 0,
-  "cpu_min_duration": 0,
-  "cpu_max_duration": 0,
-  "cpu_std_dev": 0,
-  "gpu_duration": 0,
-  "gpu_min_duration": 0,
-  "gpu_max_duration": 0,
-  "gpu_std_dev": 0,
-  "npu_duration": 0,
-  "npu_min_duration": 0,
-  "npu_max_duration": 0,
-  "npu_std_dev": 0,
   "in_dim_0": 1,
   "in_dim_1": 64,
   "in_dim_2": 64,
@@ -38,7 +24,5 @@
         "cpu_revision": ""
       }
     }
-  },
-  "npu_error": "timeout or failed",
-  "gpu_error": "timeout or failed"
+  }
 }

--- a/ab/nn/stat/run/tflite/fp32/img-classification_cifar-10_acc_unq-ecc8548dee08ffb1ab8cc7bb73ff2e89/android_STK-L21.json
+++ b/ab/nn/stat/run/tflite/fp32/img-classification_cifar-10_acc_unq-ecc8548dee08ffb1ab8cc7bb73ff2e89/android_STK-L21.json
@@ -2,23 +2,9 @@
   "model_name": "unq-ecc8548dee08ffb1ab8cc7bb73ff2e89",
   "device_type": "STK-L21",
   "os_version": "10 | HUAWEISTK-L21",
-  "valid": true,
+  "valid": false,
   "emulator": false,
   "iterations": 20,
-  "duration": 0,
-  "unit": "Failed",
-  "cpu_duration": 0,
-  "cpu_min_duration": 0,
-  "cpu_max_duration": 0,
-  "cpu_std_dev": 0,
-  "gpu_duration": 0,
-  "gpu_min_duration": 0,
-  "gpu_max_duration": 0,
-  "gpu_std_dev": 0,
-  "npu_duration": 0,
-  "npu_min_duration": 0,
-  "npu_max_duration": 0,
-  "npu_std_dev": 0,
   "in_dim_0": 1,
   "in_dim_1": 64,
   "in_dim_2": 64,
@@ -38,7 +24,5 @@
         "cpu_revision": ""
       }
     }
-  },
-  "npu_error": "timeout or failed",
-  "gpu_error": "timeout or failed"
+  }
 }

--- a/ab/nn/stat/run/tflite/fp32/img-classification_cifar-10_acc_unq-ed4c857aaa7ed54bd6ebd0e234cb9e13/android_STK-L21.json
+++ b/ab/nn/stat/run/tflite/fp32/img-classification_cifar-10_acc_unq-ed4c857aaa7ed54bd6ebd0e234cb9e13/android_STK-L21.json
@@ -2,23 +2,9 @@
   "model_name": "unq-ed4c857aaa7ed54bd6ebd0e234cb9e13",
   "device_type": "STK-L21",
   "os_version": "10 | HUAWEISTK-L21",
-  "valid": true,
+  "valid": false,
   "emulator": false,
   "iterations": 20,
-  "duration": 0,
-  "unit": "Failed",
-  "cpu_duration": 0,
-  "cpu_min_duration": 0,
-  "cpu_max_duration": 0,
-  "cpu_std_dev": 0,
-  "gpu_duration": 0,
-  "gpu_min_duration": 0,
-  "gpu_max_duration": 0,
-  "gpu_std_dev": 0,
-  "npu_duration": 0,
-  "npu_min_duration": 0,
-  "npu_max_duration": 0,
-  "npu_std_dev": 0,
   "in_dim_0": 1,
   "in_dim_1": 64,
   "in_dim_2": 64,
@@ -38,7 +24,5 @@
         "cpu_revision": ""
       }
     }
-  },
-  "npu_error": "timeout or failed",
-  "gpu_error": "timeout or failed"
+  }
 }

--- a/ab/nn/stat/run/tflite/fp32/img-classification_cifar-10_acc_unq-ed9addff13fd74726eeec33bc160856a/android_STK-L21.json
+++ b/ab/nn/stat/run/tflite/fp32/img-classification_cifar-10_acc_unq-ed9addff13fd74726eeec33bc160856a/android_STK-L21.json
@@ -2,23 +2,9 @@
   "model_name": "unq-ed9addff13fd74726eeec33bc160856a",
   "device_type": "STK-L21",
   "os_version": "10 | HUAWEISTK-L21",
-  "valid": true,
+  "valid": false,
   "emulator": false,
   "iterations": 20,
-  "duration": 0,
-  "unit": "Failed",
-  "cpu_duration": 0,
-  "cpu_min_duration": 0,
-  "cpu_max_duration": 0,
-  "cpu_std_dev": 0,
-  "gpu_duration": 0,
-  "gpu_min_duration": 0,
-  "gpu_max_duration": 0,
-  "gpu_std_dev": 0,
-  "npu_duration": 0,
-  "npu_min_duration": 0,
-  "npu_max_duration": 0,
-  "npu_std_dev": 0,
   "in_dim_0": 1,
   "in_dim_1": 31,
   "in_dim_2": 31,
@@ -38,7 +24,5 @@
         "cpu_revision": ""
       }
     }
-  },
-  "npu_error": "timeout or failed",
-  "gpu_error": "timeout or failed"
+  }
 }

--- a/ab/nn/stat/run/tflite/fp32/img-classification_cifar-10_acc_unq-eef1ae6ae969e09d73a29589bcc0d12d/android_STK-L21.json
+++ b/ab/nn/stat/run/tflite/fp32/img-classification_cifar-10_acc_unq-eef1ae6ae969e09d73a29589bcc0d12d/android_STK-L21.json
@@ -2,23 +2,9 @@
   "model_name": "unq-eef1ae6ae969e09d73a29589bcc0d12d",
   "device_type": "STK-L21",
   "os_version": "10 | HUAWEISTK-L21",
-  "valid": true,
+  "valid": false,
   "emulator": false,
   "iterations": 20,
-  "duration": 0,
-  "unit": "Failed",
-  "cpu_duration": 0,
-  "cpu_min_duration": 0,
-  "cpu_max_duration": 0,
-  "cpu_std_dev": 0,
-  "gpu_duration": 0,
-  "gpu_min_duration": 0,
-  "gpu_max_duration": 0,
-  "gpu_std_dev": 0,
-  "npu_duration": 0,
-  "npu_min_duration": 0,
-  "npu_max_duration": 0,
-  "npu_std_dev": 0,
   "in_dim_0": 1,
   "in_dim_1": 64,
   "in_dim_2": 64,
@@ -38,7 +24,5 @@
         "cpu_revision": ""
       }
     }
-  },
-  "npu_error": "timeout or failed",
-  "gpu_error": "timeout or failed"
+  }
 }

--- a/ab/nn/stat/run/tflite/fp32/img-classification_cifar-10_acc_unq-ef3f42e4c47f693dd8dcbcddca682295/android_STK-L21.json
+++ b/ab/nn/stat/run/tflite/fp32/img-classification_cifar-10_acc_unq-ef3f42e4c47f693dd8dcbcddca682295/android_STK-L21.json
@@ -2,23 +2,9 @@
   "model_name": "unq-ef3f42e4c47f693dd8dcbcddca682295",
   "device_type": "STK-L21",
   "os_version": "10 | HUAWEISTK-L21",
-  "valid": true,
+  "valid": false,
   "emulator": false,
   "iterations": 20,
-  "duration": 0,
-  "unit": "Failed",
-  "cpu_duration": 0,
-  "cpu_min_duration": 0,
-  "cpu_max_duration": 0,
-  "cpu_std_dev": 0,
-  "gpu_duration": 0,
-  "gpu_min_duration": 0,
-  "gpu_max_duration": 0,
-  "gpu_std_dev": 0,
-  "npu_duration": 0,
-  "npu_min_duration": 0,
-  "npu_max_duration": 0,
-  "npu_std_dev": 0,
   "in_dim_0": 1,
   "in_dim_1": 128,
   "in_dim_2": 128,
@@ -38,7 +24,5 @@
         "cpu_revision": ""
       }
     }
-  },
-  "npu_error": "timeout or failed",
-  "gpu_error": "timeout or failed"
+  }
 }

--- a/ab/nn/stat/run/tflite/fp32/img-classification_cifar-10_acc_unq-f06c45546807e328c053aa06ab41b122/android_STK-L21.json
+++ b/ab/nn/stat/run/tflite/fp32/img-classification_cifar-10_acc_unq-f06c45546807e328c053aa06ab41b122/android_STK-L21.json
@@ -2,23 +2,9 @@
   "model_name": "unq-f06c45546807e328c053aa06ab41b122",
   "device_type": "STK-L21",
   "os_version": "10 | HUAWEISTK-L21",
-  "valid": true,
+  "valid": false,
   "emulator": false,
   "iterations": 20,
-  "duration": 0,
-  "unit": "Failed",
-  "cpu_duration": 0,
-  "cpu_min_duration": 0,
-  "cpu_max_duration": 0,
-  "cpu_std_dev": 0,
-  "gpu_duration": 0,
-  "gpu_min_duration": 0,
-  "gpu_max_duration": 0,
-  "gpu_std_dev": 0,
-  "npu_duration": 0,
-  "npu_min_duration": 0,
-  "npu_max_duration": 0,
-  "npu_std_dev": 0,
   "in_dim_0": 1,
   "in_dim_1": 32,
   "in_dim_2": 32,
@@ -38,7 +24,5 @@
         "cpu_revision": ""
       }
     }
-  },
-  "npu_error": "timeout or failed",
-  "gpu_error": "timeout or failed"
+  }
 }

--- a/ab/nn/stat/run/tflite/fp32/img-classification_cifar-10_acc_unq-f0c6572e1066b3fdae37750b6cb8fdbc/android_STK-L21.json
+++ b/ab/nn/stat/run/tflite/fp32/img-classification_cifar-10_acc_unq-f0c6572e1066b3fdae37750b6cb8fdbc/android_STK-L21.json
@@ -2,23 +2,9 @@
   "model_name": "unq-f0c6572e1066b3fdae37750b6cb8fdbc",
   "device_type": "STK-L21",
   "os_version": "10 | HUAWEISTK-L21",
-  "valid": true,
+  "valid": false,
   "emulator": false,
   "iterations": 20,
-  "duration": 0,
-  "unit": "Failed",
-  "cpu_duration": 0,
-  "cpu_min_duration": 0,
-  "cpu_max_duration": 0,
-  "cpu_std_dev": 0,
-  "gpu_duration": 0,
-  "gpu_min_duration": 0,
-  "gpu_max_duration": 0,
-  "gpu_std_dev": 0,
-  "npu_duration": 0,
-  "npu_min_duration": 0,
-  "npu_max_duration": 0,
-  "npu_std_dev": 0,
   "in_dim_0": 1,
   "in_dim_1": 64,
   "in_dim_2": 64,
@@ -38,7 +24,5 @@
         "cpu_revision": ""
       }
     }
-  },
-  "npu_error": "timeout or failed",
-  "gpu_error": "timeout or failed"
+  }
 }

--- a/ab/nn/stat/run/tflite/fp32/img-classification_cifar-10_acc_unq-f0ecd8ad758261d3a40b41d1c276cab9/android_STK-L21.json
+++ b/ab/nn/stat/run/tflite/fp32/img-classification_cifar-10_acc_unq-f0ecd8ad758261d3a40b41d1c276cab9/android_STK-L21.json
@@ -2,23 +2,9 @@
   "model_name": "unq-f0ecd8ad758261d3a40b41d1c276cab9",
   "device_type": "STK-L21",
   "os_version": "10 | HUAWEISTK-L21",
-  "valid": true,
+  "valid": false,
   "emulator": false,
   "iterations": 20,
-  "duration": 0,
-  "unit": "Failed",
-  "cpu_duration": 0,
-  "cpu_min_duration": 0,
-  "cpu_max_duration": 0,
-  "cpu_std_dev": 0,
-  "gpu_duration": 0,
-  "gpu_min_duration": 0,
-  "gpu_max_duration": 0,
-  "gpu_std_dev": 0,
-  "npu_duration": 0,
-  "npu_min_duration": 0,
-  "npu_max_duration": 0,
-  "npu_std_dev": 0,
   "in_dim_0": 1,
   "in_dim_1": 32,
   "in_dim_2": 32,
@@ -38,7 +24,5 @@
         "cpu_revision": ""
       }
     }
-  },
-  "npu_error": "timeout or failed",
-  "gpu_error": "timeout or failed"
+  }
 }

--- a/ab/nn/stat/run/tflite/fp32/img-classification_cifar-10_acc_unq-f155edbe6b59e283d67928708892fe22/android_STK-L21.json
+++ b/ab/nn/stat/run/tflite/fp32/img-classification_cifar-10_acc_unq-f155edbe6b59e283d67928708892fe22/android_STK-L21.json
@@ -2,23 +2,9 @@
   "model_name": "unq-f155edbe6b59e283d67928708892fe22",
   "device_type": "STK-L21",
   "os_version": "10 | HUAWEISTK-L21",
-  "valid": true,
+  "valid": false,
   "emulator": false,
   "iterations": 20,
-  "duration": 0,
-  "unit": "Failed",
-  "cpu_duration": 0,
-  "cpu_min_duration": 0,
-  "cpu_max_duration": 0,
-  "cpu_std_dev": 0,
-  "gpu_duration": 0,
-  "gpu_min_duration": 0,
-  "gpu_max_duration": 0,
-  "gpu_std_dev": 0,
-  "npu_duration": 0,
-  "npu_min_duration": 0,
-  "npu_max_duration": 0,
-  "npu_std_dev": 0,
   "in_dim_0": 1,
   "in_dim_1": 128,
   "in_dim_2": 128,
@@ -38,7 +24,5 @@
         "cpu_revision": ""
       }
     }
-  },
-  "npu_error": "timeout or failed",
-  "gpu_error": "timeout or failed"
+  }
 }

--- a/ab/nn/stat/run/tflite/fp32/img-classification_cifar-10_acc_unq-f18ee05bf0bfa1a7fb5f3c01098681b4/android_STK-L21.json
+++ b/ab/nn/stat/run/tflite/fp32/img-classification_cifar-10_acc_unq-f18ee05bf0bfa1a7fb5f3c01098681b4/android_STK-L21.json
@@ -2,23 +2,9 @@
   "model_name": "unq-f18ee05bf0bfa1a7fb5f3c01098681b4",
   "device_type": "STK-L21",
   "os_version": "10 | HUAWEISTK-L21",
-  "valid": true,
+  "valid": false,
   "emulator": false,
   "iterations": 20,
-  "duration": 0,
-  "unit": "Failed",
-  "cpu_duration": 0,
-  "cpu_min_duration": 0,
-  "cpu_max_duration": 0,
-  "cpu_std_dev": 0,
-  "gpu_duration": 0,
-  "gpu_min_duration": 0,
-  "gpu_max_duration": 0,
-  "gpu_std_dev": 0,
-  "npu_duration": 0,
-  "npu_min_duration": 0,
-  "npu_max_duration": 0,
-  "npu_std_dev": 0,
   "in_dim_0": 1,
   "in_dim_1": 64,
   "in_dim_2": 64,
@@ -38,7 +24,5 @@
         "cpu_revision": ""
       }
     }
-  },
-  "npu_error": "timeout or failed",
-  "gpu_error": "timeout or failed"
+  }
 }

--- a/ab/nn/stat/run/tflite/fp32/img-classification_cifar-10_acc_unq-f1b81d27a39d43bdce8da6c45c3b9259/android_STK-L21.json
+++ b/ab/nn/stat/run/tflite/fp32/img-classification_cifar-10_acc_unq-f1b81d27a39d43bdce8da6c45c3b9259/android_STK-L21.json
@@ -2,23 +2,9 @@
   "model_name": "unq-f1b81d27a39d43bdce8da6c45c3b9259",
   "device_type": "STK-L21",
   "os_version": "10 | HUAWEISTK-L21",
-  "valid": true,
+  "valid": false,
   "emulator": false,
   "iterations": 20,
-  "duration": 0,
-  "unit": "Failed",
-  "cpu_duration": 0,
-  "cpu_min_duration": 0,
-  "cpu_max_duration": 0,
-  "cpu_std_dev": 0,
-  "gpu_duration": 0,
-  "gpu_min_duration": 0,
-  "gpu_max_duration": 0,
-  "gpu_std_dev": 0,
-  "npu_duration": 0,
-  "npu_min_duration": 0,
-  "npu_max_duration": 0,
-  "npu_std_dev": 0,
   "in_dim_0": 1,
   "in_dim_1": 32,
   "in_dim_2": 32,
@@ -38,7 +24,5 @@
         "cpu_revision": ""
       }
     }
-  },
-  "npu_error": "timeout or failed",
-  "gpu_error": "timeout or failed"
+  }
 }

--- a/ab/nn/stat/run/tflite/fp32/img-classification_cifar-10_acc_unq-f209e0eb5446c5ea371996400170a99c/android_STK-L21.json
+++ b/ab/nn/stat/run/tflite/fp32/img-classification_cifar-10_acc_unq-f209e0eb5446c5ea371996400170a99c/android_STK-L21.json
@@ -2,23 +2,9 @@
   "model_name": "unq-f209e0eb5446c5ea371996400170a99c",
   "device_type": "STK-L21",
   "os_version": "10 | HUAWEISTK-L21",
-  "valid": true,
+  "valid": false,
   "emulator": false,
   "iterations": 20,
-  "duration": 0,
-  "unit": "Failed",
-  "cpu_duration": 0,
-  "cpu_min_duration": 0,
-  "cpu_max_duration": 0,
-  "cpu_std_dev": 0,
-  "gpu_duration": 0,
-  "gpu_min_duration": 0,
-  "gpu_max_duration": 0,
-  "gpu_std_dev": 0,
-  "npu_duration": 0,
-  "npu_min_duration": 0,
-  "npu_max_duration": 0,
-  "npu_std_dev": 0,
   "in_dim_0": 1,
   "in_dim_1": 64,
   "in_dim_2": 64,
@@ -38,7 +24,5 @@
         "cpu_revision": ""
       }
     }
-  },
-  "npu_error": "timeout or failed",
-  "gpu_error": "timeout or failed"
+  }
 }

--- a/ab/nn/stat/run/tflite/fp32/img-classification_cifar-10_acc_unq-f20ed3d398867a319ffa09df1576b0f3/android_STK-L21.json
+++ b/ab/nn/stat/run/tflite/fp32/img-classification_cifar-10_acc_unq-f20ed3d398867a319ffa09df1576b0f3/android_STK-L21.json
@@ -2,23 +2,9 @@
   "model_name": "unq-f20ed3d398867a319ffa09df1576b0f3",
   "device_type": "STK-L21",
   "os_version": "10 | HUAWEISTK-L21",
-  "valid": true,
+  "valid": false,
   "emulator": false,
   "iterations": 20,
-  "duration": 0,
-  "unit": "Failed",
-  "cpu_duration": 0,
-  "cpu_min_duration": 0,
-  "cpu_max_duration": 0,
-  "cpu_std_dev": 0,
-  "gpu_duration": 0,
-  "gpu_min_duration": 0,
-  "gpu_max_duration": 0,
-  "gpu_std_dev": 0,
-  "npu_duration": 0,
-  "npu_min_duration": 0,
-  "npu_max_duration": 0,
-  "npu_std_dev": 0,
   "in_dim_0": 1,
   "in_dim_1": 32,
   "in_dim_2": 32,
@@ -38,7 +24,5 @@
         "cpu_revision": ""
       }
     }
-  },
-  "npu_error": "timeout or failed",
-  "gpu_error": "timeout or failed"
+  }
 }

--- a/ab/nn/stat/run/tflite/fp32/img-classification_cifar-10_acc_unq-f217d7c54a672b97cf65b1831eed6ca5/android_STK-L21.json
+++ b/ab/nn/stat/run/tflite/fp32/img-classification_cifar-10_acc_unq-f217d7c54a672b97cf65b1831eed6ca5/android_STK-L21.json
@@ -2,23 +2,9 @@
   "model_name": "unq-f217d7c54a672b97cf65b1831eed6ca5",
   "device_type": "STK-L21",
   "os_version": "10 | HUAWEISTK-L21",
-  "valid": true,
+  "valid": false,
   "emulator": false,
   "iterations": 20,
-  "duration": 0,
-  "unit": "Failed",
-  "cpu_duration": 0,
-  "cpu_min_duration": 0,
-  "cpu_max_duration": 0,
-  "cpu_std_dev": 0,
-  "gpu_duration": 0,
-  "gpu_min_duration": 0,
-  "gpu_max_duration": 0,
-  "gpu_std_dev": 0,
-  "npu_duration": 0,
-  "npu_min_duration": 0,
-  "npu_max_duration": 0,
-  "npu_std_dev": 0,
   "in_dim_0": 1,
   "in_dim_1": 32,
   "in_dim_2": 32,
@@ -38,7 +24,5 @@
         "cpu_revision": ""
       }
     }
-  },
-  "npu_error": "timeout or failed",
-  "gpu_error": "timeout or failed"
+  }
 }

--- a/ab/nn/stat/run/tflite/fp32/img-classification_cifar-10_acc_unq-f21bf73deec92c93b2e8560484e05d2a/android_STK-L21.json
+++ b/ab/nn/stat/run/tflite/fp32/img-classification_cifar-10_acc_unq-f21bf73deec92c93b2e8560484e05d2a/android_STK-L21.json
@@ -2,23 +2,9 @@
   "model_name": "unq-f21bf73deec92c93b2e8560484e05d2a",
   "device_type": "STK-L21",
   "os_version": "10 | HUAWEISTK-L21",
-  "valid": true,
+  "valid": false,
   "emulator": false,
   "iterations": 20,
-  "duration": 0,
-  "unit": "Failed",
-  "cpu_duration": 0,
-  "cpu_min_duration": 0,
-  "cpu_max_duration": 0,
-  "cpu_std_dev": 0,
-  "gpu_duration": 0,
-  "gpu_min_duration": 0,
-  "gpu_max_duration": 0,
-  "gpu_std_dev": 0,
-  "npu_duration": 0,
-  "npu_min_duration": 0,
-  "npu_max_duration": 0,
-  "npu_std_dev": 0,
   "in_dim_0": 1,
   "in_dim_1": 64,
   "in_dim_2": 64,
@@ -38,7 +24,5 @@
         "cpu_revision": ""
       }
     }
-  },
-  "npu_error": "timeout or failed",
-  "gpu_error": "timeout or failed"
+  }
 }

--- a/ab/nn/stat/run/tflite/int8/img-classification_cifar-10_acc_AirNext/android_STK-L21.json
+++ b/ab/nn/stat/run/tflite/int8/img-classification_cifar-10_acc_AirNext/android_STK-L21.json
@@ -2,23 +2,9 @@
   "model_name": "AirNext",
   "device_type": "STK-L21",
   "os_version": "10 | HUAWEISTK-L21",
-  "valid": true,
+  "valid": false,
   "emulator": false,
   "iterations": 20,
-  "duration": 0,
-  "unit": "Failed",
-  "cpu_duration": 0,
-  "cpu_min_duration": 0,
-  "cpu_max_duration": 0,
-  "cpu_std_dev": 0,
-  "gpu_duration": 0,
-  "gpu_min_duration": 0,
-  "gpu_max_duration": 0,
-  "gpu_std_dev": 0,
-  "npu_duration": 0,
-  "npu_min_duration": 0,
-  "npu_max_duration": 0,
-  "npu_std_dev": 0,
   "total_ram_kb": 3775716,
   "free_ram_kb": 295224,
   "available_ram_kb": 1673464,
@@ -83,7 +69,5 @@
         "cpu_revision": "2"
       }
     }
-  },
-  "npu_error": "timeout or failed",
-  "gpu_error": "timeout or failed"
+  }
 }

--- a/ab/nn/stat/run/tflite/int8/img-classification_cifar-10_acc_BagNet/android_STK-L21.json
+++ b/ab/nn/stat/run/tflite/int8/img-classification_cifar-10_acc_BagNet/android_STK-L21.json
@@ -2,23 +2,9 @@
   "model_name": "BagNet",
   "device_type": "STK-L21",
   "os_version": "10 | HUAWEISTK-L21",
-  "valid": true,
+  "valid": false,
   "emulator": false,
   "iterations": 20,
-  "duration": 0,
-  "unit": "Failed",
-  "cpu_duration": 0,
-  "cpu_min_duration": 0,
-  "cpu_max_duration": 0,
-  "cpu_std_dev": 0,
-  "gpu_duration": 0,
-  "gpu_min_duration": 0,
-  "gpu_max_duration": 0,
-  "gpu_std_dev": 0,
-  "npu_duration": 0,
-  "npu_min_duration": 0,
-  "npu_max_duration": 0,
-  "npu_std_dev": 0,
   "total_ram_kb": 3775716,
   "free_ram_kb": 693076,
   "available_ram_kb": 1855360,
@@ -83,7 +69,5 @@
         "cpu_revision": "2"
       }
     }
-  },
-  "npu_error": "timeout or failed",
-  "gpu_error": "timeout or failed"
+  }
 }

--- a/ab/nn/stat/run/tflite/int8/img-classification_cifar-10_acc_MoE-hetero4-Alex-Dense-Air-Bag/android_STK-L21.json
+++ b/ab/nn/stat/run/tflite/int8/img-classification_cifar-10_acc_MoE-hetero4-Alex-Dense-Air-Bag/android_STK-L21.json
@@ -2,23 +2,9 @@
   "model_name": "MoE-hetero4-Alex-Dense-Air-Bag",
   "device_type": "STK-L21",
   "os_version": "10 | HUAWEISTK-L21",
-  "valid": true,
+  "valid": false,
   "emulator": false,
   "iterations": 20,
-  "duration": 0,
-  "unit": "Failed",
-  "cpu_duration": 0,
-  "cpu_min_duration": 0,
-  "cpu_max_duration": 0,
-  "cpu_std_dev": 0,
-  "gpu_duration": 0,
-  "gpu_min_duration": 0,
-  "gpu_max_duration": 0,
-  "gpu_std_dev": 0,
-  "npu_duration": 0,
-  "npu_min_duration": 0,
-  "npu_max_duration": 0,
-  "npu_std_dev": 0,
   "total_ram_kb": 3775716,
   "free_ram_kb": 858248,
   "available_ram_kb": 2025708,
@@ -83,7 +69,5 @@
         "cpu_revision": "2"
       }
     }
-  },
-  "npu_error": "timeout or failed",
-  "gpu_error": "timeout or failed"
+  }
 }

--- a/ab/nn/stat/run/tflite/int8/img-classification_cifar-10_acc_unq-e1c6d812a3eb56cf7a120830088fad7a/android_STK-L21.json
+++ b/ab/nn/stat/run/tflite/int8/img-classification_cifar-10_acc_unq-e1c6d812a3eb56cf7a120830088fad7a/android_STK-L21.json
@@ -2,23 +2,9 @@
   "model_name": "unq-e1c6d812a3eb56cf7a120830088fad7a",
   "device_type": "STK-L21",
   "os_version": "10 | HUAWEISTK-L21",
-  "valid": true,
+  "valid": false,
   "emulator": false,
   "iterations": 20,
-  "duration": 0,
-  "unit": "Failed",
-  "cpu_duration": 0,
-  "cpu_min_duration": 0,
-  "cpu_max_duration": 0,
-  "cpu_std_dev": 0,
-  "gpu_duration": 0,
-  "gpu_min_duration": 0,
-  "gpu_max_duration": 0,
-  "gpu_std_dev": 0,
-  "npu_duration": 0,
-  "npu_min_duration": 0,
-  "npu_max_duration": 0,
-  "npu_std_dev": 0,
   "in_dim_0": 1,
   "in_dim_1": 3,
   "in_dim_2": 3,
@@ -38,7 +24,5 @@
         "cpu_revision": ""
       }
     }
-  },
-  "npu_error": "timeout or failed",
-  "gpu_error": "timeout or failed"
+  }
 }

--- a/ab/nn/stat/run/tflite/int8/img-classification_cifar-10_acc_unq-e273123056fb7b373e10474352e3a475/android_STK-L21.json
+++ b/ab/nn/stat/run/tflite/int8/img-classification_cifar-10_acc_unq-e273123056fb7b373e10474352e3a475/android_STK-L21.json
@@ -2,23 +2,9 @@
   "model_name": "unq-e273123056fb7b373e10474352e3a475",
   "device_type": "STK-L21",
   "os_version": "10 | HUAWEISTK-L21",
-  "valid": true,
+  "valid": false,
   "emulator": false,
   "iterations": 20,
-  "duration": 0,
-  "unit": "Failed",
-  "cpu_duration": 0,
-  "cpu_min_duration": 0,
-  "cpu_max_duration": 0,
-  "cpu_std_dev": 0,
-  "gpu_duration": 0,
-  "gpu_min_duration": 0,
-  "gpu_max_duration": 0,
-  "gpu_std_dev": 0,
-  "npu_duration": 0,
-  "npu_min_duration": 0,
-  "npu_max_duration": 0,
-  "npu_std_dev": 0,
   "in_dim_0": 1,
   "in_dim_1": 64,
   "in_dim_2": 64,
@@ -38,7 +24,5 @@
         "cpu_revision": ""
       }
     }
-  },
-  "npu_error": "timeout or failed",
-  "gpu_error": "timeout or failed"
+  }
 }

--- a/ab/nn/stat/run/tflite/int8/img-classification_cifar-10_acc_unq-e3728da7bcd5f8199ea16c9439847e8f/android_STK-L21.json
+++ b/ab/nn/stat/run/tflite/int8/img-classification_cifar-10_acc_unq-e3728da7bcd5f8199ea16c9439847e8f/android_STK-L21.json
@@ -2,23 +2,9 @@
   "model_name": "unq-e3728da7bcd5f8199ea16c9439847e8f",
   "device_type": "STK-L21",
   "os_version": "10 | HUAWEISTK-L21",
-  "valid": true,
+  "valid": false,
   "emulator": false,
   "iterations": 20,
-  "duration": 0,
-  "unit": "Failed",
-  "cpu_duration": 0,
-  "cpu_min_duration": 0,
-  "cpu_max_duration": 0,
-  "cpu_std_dev": 0,
-  "gpu_duration": 0,
-  "gpu_min_duration": 0,
-  "gpu_max_duration": 0,
-  "gpu_std_dev": 0,
-  "npu_duration": 0,
-  "npu_min_duration": 0,
-  "npu_max_duration": 0,
-  "npu_std_dev": 0,
   "in_dim_0": 1,
   "in_dim_1": 64,
   "in_dim_2": 64,
@@ -38,7 +24,5 @@
         "cpu_revision": ""
       }
     }
-  },
-  "npu_error": "timeout or failed",
-  "gpu_error": "timeout or failed"
+  }
 }

--- a/ab/nn/stat/run/tflite/int8/img-classification_cifar-10_acc_unq-e379e94250005861fb8816daa9c5b0d8/android_STK-L21.json
+++ b/ab/nn/stat/run/tflite/int8/img-classification_cifar-10_acc_unq-e379e94250005861fb8816daa9c5b0d8/android_STK-L21.json
@@ -2,23 +2,9 @@
   "model_name": "unq-e379e94250005861fb8816daa9c5b0d8",
   "device_type": "STK-L21",
   "os_version": "10 | HUAWEISTK-L21",
-  "valid": true,
+  "valid": false,
   "emulator": false,
   "iterations": 20,
-  "duration": 0,
-  "unit": "Failed",
-  "cpu_duration": 0,
-  "cpu_min_duration": 0,
-  "cpu_max_duration": 0,
-  "cpu_std_dev": 0,
-  "gpu_duration": 0,
-  "gpu_min_duration": 0,
-  "gpu_max_duration": 0,
-  "gpu_std_dev": 0,
-  "npu_duration": 0,
-  "npu_min_duration": 0,
-  "npu_max_duration": 0,
-  "npu_std_dev": 0,
   "in_dim_0": 1,
   "in_dim_1": 64,
   "in_dim_2": 64,
@@ -38,7 +24,5 @@
         "cpu_revision": ""
       }
     }
-  },
-  "npu_error": "timeout or failed",
-  "gpu_error": "timeout or failed"
+  }
 }

--- a/ab/nn/stat/run/tflite/int8/img-classification_cifar-10_acc_unq-e3aec622909575e3f83b28220a34da3f/android_STK-L21.json
+++ b/ab/nn/stat/run/tflite/int8/img-classification_cifar-10_acc_unq-e3aec622909575e3f83b28220a34da3f/android_STK-L21.json
@@ -2,23 +2,9 @@
   "model_name": "unq-e3aec622909575e3f83b28220a34da3f",
   "device_type": "STK-L21",
   "os_version": "10 | HUAWEISTK-L21",
-  "valid": true,
+  "valid": false,
   "emulator": false,
   "iterations": 20,
-  "duration": 0,
-  "unit": "Failed",
-  "cpu_duration": 0,
-  "cpu_min_duration": 0,
-  "cpu_max_duration": 0,
-  "cpu_std_dev": 0,
-  "gpu_duration": 0,
-  "gpu_min_duration": 0,
-  "gpu_max_duration": 0,
-  "gpu_std_dev": 0,
-  "npu_duration": 0,
-  "npu_min_duration": 0,
-  "npu_max_duration": 0,
-  "npu_std_dev": 0,
   "in_dim_0": 1,
   "in_dim_1": 64,
   "in_dim_2": 64,
@@ -38,7 +24,5 @@
         "cpu_revision": ""
       }
     }
-  },
-  "npu_error": "timeout or failed",
-  "gpu_error": "timeout or failed"
+  }
 }

--- a/ab/nn/stat/run/tflite/int8/img-classification_cifar-10_acc_unq-e3d674bb2ddc2a203ae9e18092097b24/android_STK-L21.json
+++ b/ab/nn/stat/run/tflite/int8/img-classification_cifar-10_acc_unq-e3d674bb2ddc2a203ae9e18092097b24/android_STK-L21.json
@@ -2,23 +2,9 @@
   "model_name": "unq-e3d674bb2ddc2a203ae9e18092097b24",
   "device_type": "STK-L21",
   "os_version": "10 | HUAWEISTK-L21",
-  "valid": true,
+  "valid": false,
   "emulator": false,
   "iterations": 20,
-  "duration": 0,
-  "unit": "Failed",
-  "cpu_duration": 0,
-  "cpu_min_duration": 0,
-  "cpu_max_duration": 0,
-  "cpu_std_dev": 0,
-  "gpu_duration": 0,
-  "gpu_min_duration": 0,
-  "gpu_max_duration": 0,
-  "gpu_std_dev": 0,
-  "npu_duration": 0,
-  "npu_min_duration": 0,
-  "npu_max_duration": 0,
-  "npu_std_dev": 0,
   "in_dim_0": 1,
   "in_dim_1": 31,
   "in_dim_2": 31,
@@ -38,7 +24,5 @@
         "cpu_revision": ""
       }
     }
-  },
-  "npu_error": "timeout or failed",
-  "gpu_error": "timeout or failed"
+  }
 }

--- a/ab/nn/stat/run/tflite/int8/img-classification_cifar-10_acc_unq-e3fbb5272ddcb9c30f6782f3d2c6b015/android_STK-L21.json
+++ b/ab/nn/stat/run/tflite/int8/img-classification_cifar-10_acc_unq-e3fbb5272ddcb9c30f6782f3d2c6b015/android_STK-L21.json
@@ -2,23 +2,9 @@
   "model_name": "unq-e3fbb5272ddcb9c30f6782f3d2c6b015",
   "device_type": "STK-L21",
   "os_version": "10 | HUAWEISTK-L21",
-  "valid": true,
+  "valid": false,
   "emulator": false,
   "iterations": 20,
-  "duration": 0,
-  "unit": "Failed",
-  "cpu_duration": 0,
-  "cpu_min_duration": 0,
-  "cpu_max_duration": 0,
-  "cpu_std_dev": 0,
-  "gpu_duration": 0,
-  "gpu_min_duration": 0,
-  "gpu_max_duration": 0,
-  "gpu_std_dev": 0,
-  "npu_duration": 0,
-  "npu_min_duration": 0,
-  "npu_max_duration": 0,
-  "npu_std_dev": 0,
   "in_dim_0": 1,
   "in_dim_1": 64,
   "in_dim_2": 64,
@@ -38,7 +24,5 @@
         "cpu_revision": ""
       }
     }
-  },
-  "npu_error": "timeout or failed",
-  "gpu_error": "timeout or failed"
+  }
 }

--- a/ab/nn/stat/run/tflite/int8/img-classification_cifar-10_acc_unq-e3fbebacee71560dedd5007ca6a38c49/android_STK-L21.json
+++ b/ab/nn/stat/run/tflite/int8/img-classification_cifar-10_acc_unq-e3fbebacee71560dedd5007ca6a38c49/android_STK-L21.json
@@ -2,23 +2,9 @@
   "model_name": "unq-e3fbebacee71560dedd5007ca6a38c49",
   "device_type": "STK-L21",
   "os_version": "10 | HUAWEISTK-L21",
-  "valid": true,
+  "valid": false,
   "emulator": false,
   "iterations": 20,
-  "duration": 0,
-  "unit": "Failed",
-  "cpu_duration": 0,
-  "cpu_min_duration": 0,
-  "cpu_max_duration": 0,
-  "cpu_std_dev": 0,
-  "gpu_duration": 0,
-  "gpu_min_duration": 0,
-  "gpu_max_duration": 0,
-  "gpu_std_dev": 0,
-  "npu_duration": 0,
-  "npu_min_duration": 0,
-  "npu_max_duration": 0,
-  "npu_std_dev": 0,
   "in_dim_0": 1,
   "in_dim_1": 64,
   "in_dim_2": 64,
@@ -38,7 +24,5 @@
         "cpu_revision": ""
       }
     }
-  },
-  "npu_error": "timeout or failed",
-  "gpu_error": "timeout or failed"
+  }
 }

--- a/ab/nn/stat/run/tflite/int8/img-classification_cifar-10_acc_unq-e44ae24011ab6ce02881cea9e1fd8422/android_STK-L21.json
+++ b/ab/nn/stat/run/tflite/int8/img-classification_cifar-10_acc_unq-e44ae24011ab6ce02881cea9e1fd8422/android_STK-L21.json
@@ -2,23 +2,9 @@
   "model_name": "unq-e44ae24011ab6ce02881cea9e1fd8422",
   "device_type": "STK-L21",
   "os_version": "10 | HUAWEISTK-L21",
-  "valid": true,
+  "valid": false,
   "emulator": false,
   "iterations": 20,
-  "duration": 0,
-  "unit": "Failed",
-  "cpu_duration": 0,
-  "cpu_min_duration": 0,
-  "cpu_max_duration": 0,
-  "cpu_std_dev": 0,
-  "gpu_duration": 0,
-  "gpu_min_duration": 0,
-  "gpu_max_duration": 0,
-  "gpu_std_dev": 0,
-  "npu_duration": 0,
-  "npu_min_duration": 0,
-  "npu_max_duration": 0,
-  "npu_std_dev": 0,
   "in_dim_0": 1,
   "in_dim_1": 30,
   "in_dim_2": 30,
@@ -38,7 +24,5 @@
         "cpu_revision": ""
       }
     }
-  },
-  "npu_error": "timeout or failed",
-  "gpu_error": "timeout or failed"
+  }
 }

--- a/ab/nn/stat/run/tflite/int8/img-classification_cifar-10_acc_unq-e44cb7a653488f81e2ae6af25c16231e/android_STK-L21.json
+++ b/ab/nn/stat/run/tflite/int8/img-classification_cifar-10_acc_unq-e44cb7a653488f81e2ae6af25c16231e/android_STK-L21.json
@@ -2,23 +2,9 @@
   "model_name": "unq-e44cb7a653488f81e2ae6af25c16231e",
   "device_type": "STK-L21",
   "os_version": "10 | HUAWEISTK-L21",
-  "valid": true,
+  "valid": false,
   "emulator": false,
   "iterations": 20,
-  "duration": 0,
-  "unit": "Failed",
-  "cpu_duration": 0,
-  "cpu_min_duration": 0,
-  "cpu_max_duration": 0,
-  "cpu_std_dev": 0,
-  "gpu_duration": 0,
-  "gpu_min_duration": 0,
-  "gpu_max_duration": 0,
-  "gpu_std_dev": 0,
-  "npu_duration": 0,
-  "npu_min_duration": 0,
-  "npu_max_duration": 0,
-  "npu_std_dev": 0,
   "in_dim_0": 1,
   "in_dim_1": 64,
   "in_dim_2": 64,
@@ -38,7 +24,5 @@
         "cpu_revision": ""
       }
     }
-  },
-  "npu_error": "timeout or failed",
-  "gpu_error": "timeout or failed"
+  }
 }

--- a/ab/nn/stat/run/tflite/int8/img-classification_cifar-10_acc_unq-e48d0591ef09fcec6a45fc75dc4602eb/android_STK-L21.json
+++ b/ab/nn/stat/run/tflite/int8/img-classification_cifar-10_acc_unq-e48d0591ef09fcec6a45fc75dc4602eb/android_STK-L21.json
@@ -2,23 +2,9 @@
   "model_name": "unq-e48d0591ef09fcec6a45fc75dc4602eb",
   "device_type": "STK-L21",
   "os_version": "10 | HUAWEISTK-L21",
-  "valid": true,
+  "valid": false,
   "emulator": false,
   "iterations": 20,
-  "duration": 0,
-  "unit": "Failed",
-  "cpu_duration": 0,
-  "cpu_min_duration": 0,
-  "cpu_max_duration": 0,
-  "cpu_std_dev": 0,
-  "gpu_duration": 0,
-  "gpu_min_duration": 0,
-  "gpu_max_duration": 0,
-  "gpu_std_dev": 0,
-  "npu_duration": 0,
-  "npu_min_duration": 0,
-  "npu_max_duration": 0,
-  "npu_std_dev": 0,
   "in_dim_0": 1,
   "in_dim_1": 64,
   "in_dim_2": 64,
@@ -38,7 +24,5 @@
         "cpu_revision": ""
       }
     }
-  },
-  "npu_error": "timeout or failed",
-  "gpu_error": "timeout or failed"
+  }
 }

--- a/ab/nn/stat/run/tflite/int8/img-classification_cifar-10_acc_unq-e5616457b750b03b15c6ac0b19f9f738/android_STK-L21.json
+++ b/ab/nn/stat/run/tflite/int8/img-classification_cifar-10_acc_unq-e5616457b750b03b15c6ac0b19f9f738/android_STK-L21.json
@@ -2,23 +2,9 @@
   "model_name": "unq-e5616457b750b03b15c6ac0b19f9f738",
   "device_type": "STK-L21",
   "os_version": "10 | HUAWEISTK-L21",
-  "valid": true,
+  "valid": false,
   "emulator": false,
   "iterations": 20,
-  "duration": 0,
-  "unit": "Failed",
-  "cpu_duration": 0,
-  "cpu_min_duration": 0,
-  "cpu_max_duration": 0,
-  "cpu_std_dev": 0,
-  "gpu_duration": 0,
-  "gpu_min_duration": 0,
-  "gpu_max_duration": 0,
-  "gpu_std_dev": 0,
-  "npu_duration": 0,
-  "npu_min_duration": 0,
-  "npu_max_duration": 0,
-  "npu_std_dev": 0,
   "in_dim_0": 1,
   "in_dim_1": 128,
   "in_dim_2": 128,
@@ -38,7 +24,5 @@
         "cpu_revision": ""
       }
     }
-  },
-  "npu_error": "timeout or failed",
-  "gpu_error": "timeout or failed"
+  }
 }

--- a/ab/nn/stat/run/tflite/int8/img-classification_cifar-10_acc_unq-e63f8eda71470d27626a3a3374a67313/android_STK-L21.json
+++ b/ab/nn/stat/run/tflite/int8/img-classification_cifar-10_acc_unq-e63f8eda71470d27626a3a3374a67313/android_STK-L21.json
@@ -2,23 +2,9 @@
   "model_name": "unq-e63f8eda71470d27626a3a3374a67313",
   "device_type": "STK-L21",
   "os_version": "10 | HUAWEISTK-L21",
-  "valid": true,
+  "valid": false,
   "emulator": false,
   "iterations": 20,
-  "duration": 0,
-  "unit": "Failed",
-  "cpu_duration": 0,
-  "cpu_min_duration": 0,
-  "cpu_max_duration": 0,
-  "cpu_std_dev": 0,
-  "gpu_duration": 0,
-  "gpu_min_duration": 0,
-  "gpu_max_duration": 0,
-  "gpu_std_dev": 0,
-  "npu_duration": 0,
-  "npu_min_duration": 0,
-  "npu_max_duration": 0,
-  "npu_std_dev": 0,
   "in_dim_0": 1,
   "in_dim_1": 30,
   "in_dim_2": 30,
@@ -38,7 +24,5 @@
         "cpu_revision": ""
       }
     }
-  },
-  "npu_error": "timeout or failed",
-  "gpu_error": "timeout or failed"
+  }
 }

--- a/ab/nn/stat/run/tflite/int8/img-classification_cifar-10_acc_unq-e829307b85fbe806e9603e92db40432c/android_STK-L21.json
+++ b/ab/nn/stat/run/tflite/int8/img-classification_cifar-10_acc_unq-e829307b85fbe806e9603e92db40432c/android_STK-L21.json
@@ -2,23 +2,9 @@
   "model_name": "unq-e829307b85fbe806e9603e92db40432c",
   "device_type": "STK-L21",
   "os_version": "10 | HUAWEISTK-L21",
-  "valid": true,
+  "valid": false,
   "emulator": false,
   "iterations": 20,
-  "duration": 0,
-  "unit": "Failed",
-  "cpu_duration": 0,
-  "cpu_min_duration": 0,
-  "cpu_max_duration": 0,
-  "cpu_std_dev": 0,
-  "gpu_duration": 0,
-  "gpu_min_duration": 0,
-  "gpu_max_duration": 0,
-  "gpu_std_dev": 0,
-  "npu_duration": 0,
-  "npu_min_duration": 0,
-  "npu_max_duration": 0,
-  "npu_std_dev": 0,
   "in_dim_0": 1,
   "in_dim_1": 256,
   "in_dim_2": 256,
@@ -38,7 +24,5 @@
         "cpu_revision": ""
       }
     }
-  },
-  "npu_error": "timeout or failed",
-  "gpu_error": "timeout or failed"
+  }
 }

--- a/ab/nn/stat/run/tflite/int8/img-classification_cifar-10_acc_unq-e8c8ffb22b408e6e21d148cb223d9f4a/android_STK-L21.json
+++ b/ab/nn/stat/run/tflite/int8/img-classification_cifar-10_acc_unq-e8c8ffb22b408e6e21d148cb223d9f4a/android_STK-L21.json
@@ -2,23 +2,9 @@
   "model_name": "unq-e8c8ffb22b408e6e21d148cb223d9f4a",
   "device_type": "STK-L21",
   "os_version": "10 | HUAWEISTK-L21",
-  "valid": true,
+  "valid": false,
   "emulator": false,
   "iterations": 20,
-  "duration": 0,
-  "unit": "Failed",
-  "cpu_duration": 0,
-  "cpu_min_duration": 0,
-  "cpu_max_duration": 0,
-  "cpu_std_dev": 0,
-  "gpu_duration": 0,
-  "gpu_min_duration": 0,
-  "gpu_max_duration": 0,
-  "gpu_std_dev": 0,
-  "npu_duration": 0,
-  "npu_min_duration": 0,
-  "npu_max_duration": 0,
-  "npu_std_dev": 0,
   "in_dim_0": 1,
   "in_dim_1": 32,
   "in_dim_2": 32,
@@ -38,7 +24,5 @@
         "cpu_revision": ""
       }
     }
-  },
-  "npu_error": "timeout or failed",
-  "gpu_error": "timeout or failed"
+  }
 }

--- a/ab/nn/stat/run/tflite/int8/img-classification_cifar-10_acc_unq-e928c5cf875eddf85c767433f1e5b49d/android_STK-L21.json
+++ b/ab/nn/stat/run/tflite/int8/img-classification_cifar-10_acc_unq-e928c5cf875eddf85c767433f1e5b49d/android_STK-L21.json
@@ -2,23 +2,9 @@
   "model_name": "unq-e928c5cf875eddf85c767433f1e5b49d",
   "device_type": "STK-L21",
   "os_version": "10 | HUAWEISTK-L21",
-  "valid": true,
+  "valid": false,
   "emulator": false,
   "iterations": 20,
-  "duration": 0,
-  "unit": "Failed",
-  "cpu_duration": 0,
-  "cpu_min_duration": 0,
-  "cpu_max_duration": 0,
-  "cpu_std_dev": 0,
-  "gpu_duration": 0,
-  "gpu_min_duration": 0,
-  "gpu_max_duration": 0,
-  "gpu_std_dev": 0,
-  "npu_duration": 0,
-  "npu_min_duration": 0,
-  "npu_max_duration": 0,
-  "npu_std_dev": 0,
   "in_dim_0": 1,
   "in_dim_1": 64,
   "in_dim_2": 64,
@@ -38,7 +24,5 @@
         "cpu_revision": ""
       }
     }
-  },
-  "npu_error": "timeout or failed",
-  "gpu_error": "timeout or failed"
+  }
 }

--- a/ab/nn/stat/run/tflite/int8/img-classification_cifar-10_acc_unq-e94b07fc7608be5f53894e9d68be1fed/android_STK-L21.json
+++ b/ab/nn/stat/run/tflite/int8/img-classification_cifar-10_acc_unq-e94b07fc7608be5f53894e9d68be1fed/android_STK-L21.json
@@ -2,23 +2,9 @@
   "model_name": "unq-e94b07fc7608be5f53894e9d68be1fed",
   "device_type": "STK-L21",
   "os_version": "10 | HUAWEISTK-L21",
-  "valid": true,
+  "valid": false,
   "emulator": false,
   "iterations": 20,
-  "duration": 0,
-  "unit": "Failed",
-  "cpu_duration": 0,
-  "cpu_min_duration": 0,
-  "cpu_max_duration": 0,
-  "cpu_std_dev": 0,
-  "gpu_duration": 0,
-  "gpu_min_duration": 0,
-  "gpu_max_duration": 0,
-  "gpu_std_dev": 0,
-  "npu_duration": 0,
-  "npu_min_duration": 0,
-  "npu_max_duration": 0,
-  "npu_std_dev": 0,
   "in_dim_0": 1,
   "in_dim_1": 64,
   "in_dim_2": 64,
@@ -38,7 +24,5 @@
         "cpu_revision": ""
       }
     }
-  },
-  "npu_error": "timeout or failed",
-  "gpu_error": "timeout or failed"
+  }
 }

--- a/ab/nn/stat/run/tflite/int8/img-classification_cifar-10_acc_unq-e95137bd067ae892db35f40987867f54/android_STK-L21.json
+++ b/ab/nn/stat/run/tflite/int8/img-classification_cifar-10_acc_unq-e95137bd067ae892db35f40987867f54/android_STK-L21.json
@@ -2,23 +2,9 @@
   "model_name": "unq-e95137bd067ae892db35f40987867f54",
   "device_type": "STK-L21",
   "os_version": "10 | HUAWEISTK-L21",
-  "valid": true,
+  "valid": false,
   "emulator": false,
   "iterations": 20,
-  "duration": 0,
-  "unit": "Failed",
-  "cpu_duration": 0,
-  "cpu_min_duration": 0,
-  "cpu_max_duration": 0,
-  "cpu_std_dev": 0,
-  "gpu_duration": 0,
-  "gpu_min_duration": 0,
-  "gpu_max_duration": 0,
-  "gpu_std_dev": 0,
-  "npu_duration": 0,
-  "npu_min_duration": 0,
-  "npu_max_duration": 0,
-  "npu_std_dev": 0,
   "in_dim_0": 1,
   "in_dim_1": 30,
   "in_dim_2": 30,
@@ -38,7 +24,5 @@
         "cpu_revision": ""
       }
     }
-  },
-  "npu_error": "timeout or failed",
-  "gpu_error": "timeout or failed"
+  }
 }

--- a/ab/nn/stat/run/tflite/int8/img-classification_cifar-10_acc_unq-e985a3423c752050b8dd9c0f3c5bfa83/android_STK-L21.json
+++ b/ab/nn/stat/run/tflite/int8/img-classification_cifar-10_acc_unq-e985a3423c752050b8dd9c0f3c5bfa83/android_STK-L21.json
@@ -2,23 +2,9 @@
   "model_name": "unq-e985a3423c752050b8dd9c0f3c5bfa83",
   "device_type": "STK-L21",
   "os_version": "10 | HUAWEISTK-L21",
-  "valid": true,
+  "valid": false,
   "emulator": false,
   "iterations": 20,
-  "duration": 0,
-  "unit": "Failed",
-  "cpu_duration": 0,
-  "cpu_min_duration": 0,
-  "cpu_max_duration": 0,
-  "cpu_std_dev": 0,
-  "gpu_duration": 0,
-  "gpu_min_duration": 0,
-  "gpu_max_duration": 0,
-  "gpu_std_dev": 0,
-  "npu_duration": 0,
-  "npu_min_duration": 0,
-  "npu_max_duration": 0,
-  "npu_std_dev": 0,
   "in_dim_0": 1,
   "in_dim_1": 64,
   "in_dim_2": 64,
@@ -38,7 +24,5 @@
         "cpu_revision": ""
       }
     }
-  },
-  "npu_error": "timeout or failed",
-  "gpu_error": "timeout or failed"
+  }
 }

--- a/ab/nn/stat/run/tflite/int8/img-classification_cifar-10_acc_unq-e99c5fdfcdaa135744e90e186feabd49/android_STK-L21.json
+++ b/ab/nn/stat/run/tflite/int8/img-classification_cifar-10_acc_unq-e99c5fdfcdaa135744e90e186feabd49/android_STK-L21.json
@@ -2,23 +2,9 @@
   "model_name": "unq-e99c5fdfcdaa135744e90e186feabd49",
   "device_type": "STK-L21",
   "os_version": "10 | HUAWEISTK-L21",
-  "valid": true,
+  "valid": false,
   "emulator": false,
   "iterations": 20,
-  "duration": 0,
-  "unit": "Failed",
-  "cpu_duration": 0,
-  "cpu_min_duration": 0,
-  "cpu_max_duration": 0,
-  "cpu_std_dev": 0,
-  "gpu_duration": 0,
-  "gpu_min_duration": 0,
-  "gpu_max_duration": 0,
-  "gpu_std_dev": 0,
-  "npu_duration": 0,
-  "npu_min_duration": 0,
-  "npu_max_duration": 0,
-  "npu_std_dev": 0,
   "in_dim_0": 1,
   "in_dim_1": 64,
   "in_dim_2": 64,
@@ -38,7 +24,5 @@
         "cpu_revision": ""
       }
     }
-  },
-  "npu_error": "timeout or failed",
-  "gpu_error": "timeout or failed"
+  }
 }

--- a/ab/nn/stat/run/tflite/int8/img-classification_cifar-10_acc_unq-e9b8a760cdc7bbf108354d00d8b5e53f/android_STK-L21.json
+++ b/ab/nn/stat/run/tflite/int8/img-classification_cifar-10_acc_unq-e9b8a760cdc7bbf108354d00d8b5e53f/android_STK-L21.json
@@ -2,23 +2,9 @@
   "model_name": "unq-e9b8a760cdc7bbf108354d00d8b5e53f",
   "device_type": "STK-L21",
   "os_version": "10 | HUAWEISTK-L21",
-  "valid": true,
+  "valid": false,
   "emulator": false,
   "iterations": 20,
-  "duration": 0,
-  "unit": "Failed",
-  "cpu_duration": 0,
-  "cpu_min_duration": 0,
-  "cpu_max_duration": 0,
-  "cpu_std_dev": 0,
-  "gpu_duration": 0,
-  "gpu_min_duration": 0,
-  "gpu_max_duration": 0,
-  "gpu_std_dev": 0,
-  "npu_duration": 0,
-  "npu_min_duration": 0,
-  "npu_max_duration": 0,
-  "npu_std_dev": 0,
   "in_dim_0": 1,
   "in_dim_1": 64,
   "in_dim_2": 64,
@@ -38,7 +24,5 @@
         "cpu_revision": ""
       }
     }
-  },
-  "npu_error": "timeout or failed",
-  "gpu_error": "timeout or failed"
+  }
 }

--- a/ab/nn/stat/run/tflite/int8/img-classification_cifar-10_acc_unq-e9d1204a1321e7fc0932595590293890/android_STK-L21.json
+++ b/ab/nn/stat/run/tflite/int8/img-classification_cifar-10_acc_unq-e9d1204a1321e7fc0932595590293890/android_STK-L21.json
@@ -2,23 +2,9 @@
   "model_name": "unq-e9d1204a1321e7fc0932595590293890",
   "device_type": "STK-L21",
   "os_version": "10 | HUAWEISTK-L21",
-  "valid": true,
+  "valid": false,
   "emulator": false,
   "iterations": 20,
-  "duration": 0,
-  "unit": "Failed",
-  "cpu_duration": 0,
-  "cpu_min_duration": 0,
-  "cpu_max_duration": 0,
-  "cpu_std_dev": 0,
-  "gpu_duration": 0,
-  "gpu_min_duration": 0,
-  "gpu_max_duration": 0,
-  "gpu_std_dev": 0,
-  "npu_duration": 0,
-  "npu_min_duration": 0,
-  "npu_max_duration": 0,
-  "npu_std_dev": 0,
   "in_dim_0": 1,
   "in_dim_1": 64,
   "in_dim_2": 64,
@@ -38,7 +24,5 @@
         "cpu_revision": ""
       }
     }
-  },
-  "npu_error": "timeout or failed",
-  "gpu_error": "timeout or failed"
+  }
 }

--- a/ab/nn/stat/run/tflite/int8/img-classification_cifar-10_acc_unq-e9f0c45f824764dbd8b4f93309a56919/android_STK-L21.json
+++ b/ab/nn/stat/run/tflite/int8/img-classification_cifar-10_acc_unq-e9f0c45f824764dbd8b4f93309a56919/android_STK-L21.json
@@ -2,23 +2,9 @@
   "model_name": "unq-e9f0c45f824764dbd8b4f93309a56919",
   "device_type": "STK-L21",
   "os_version": "10 | HUAWEISTK-L21",
-  "valid": true,
+  "valid": false,
   "emulator": false,
   "iterations": 20,
-  "duration": 0,
-  "unit": "Failed",
-  "cpu_duration": 0,
-  "cpu_min_duration": 0,
-  "cpu_max_duration": 0,
-  "cpu_std_dev": 0,
-  "gpu_duration": 0,
-  "gpu_min_duration": 0,
-  "gpu_max_duration": 0,
-  "gpu_std_dev": 0,
-  "npu_duration": 0,
-  "npu_min_duration": 0,
-  "npu_max_duration": 0,
-  "npu_std_dev": 0,
   "in_dim_0": 1,
   "in_dim_1": 32,
   "in_dim_2": 32,
@@ -38,7 +24,5 @@
         "cpu_revision": ""
       }
     }
-  },
-  "npu_error": "timeout or failed",
-  "gpu_error": "timeout or failed"
+  }
 }

--- a/ab/nn/stat/run/tflite/int8/img-classification_cifar-10_acc_unq-e9fecd5d808ceed2dbcc66099c0e8274/android_STK-L21.json
+++ b/ab/nn/stat/run/tflite/int8/img-classification_cifar-10_acc_unq-e9fecd5d808ceed2dbcc66099c0e8274/android_STK-L21.json
@@ -2,23 +2,9 @@
   "model_name": "unq-e9fecd5d808ceed2dbcc66099c0e8274",
   "device_type": "STK-L21",
   "os_version": "10 | HUAWEISTK-L21",
-  "valid": true,
+  "valid": false,
   "emulator": false,
   "iterations": 20,
-  "duration": 0,
-  "unit": "Failed",
-  "cpu_duration": 0,
-  "cpu_min_duration": 0,
-  "cpu_max_duration": 0,
-  "cpu_std_dev": 0,
-  "gpu_duration": 0,
-  "gpu_min_duration": 0,
-  "gpu_max_duration": 0,
-  "gpu_std_dev": 0,
-  "npu_duration": 0,
-  "npu_min_duration": 0,
-  "npu_max_duration": 0,
-  "npu_std_dev": 0,
   "in_dim_0": 1,
   "in_dim_1": 31,
   "in_dim_2": 31,
@@ -38,7 +24,5 @@
         "cpu_revision": ""
       }
     }
-  },
-  "npu_error": "timeout or failed",
-  "gpu_error": "timeout or failed"
+  }
 }

--- a/ab/nn/stat/run/tflite/int8/img-classification_cifar-10_acc_unq-ea2167b1d42214588e0d39e11500cd42/android_STK-L21.json
+++ b/ab/nn/stat/run/tflite/int8/img-classification_cifar-10_acc_unq-ea2167b1d42214588e0d39e11500cd42/android_STK-L21.json
@@ -2,23 +2,9 @@
   "model_name": "unq-ea2167b1d42214588e0d39e11500cd42",
   "device_type": "STK-L21",
   "os_version": "10 | HUAWEISTK-L21",
-  "valid": true,
+  "valid": false,
   "emulator": false,
   "iterations": 20,
-  "duration": 0,
-  "unit": "Failed",
-  "cpu_duration": 0,
-  "cpu_min_duration": 0,
-  "cpu_max_duration": 0,
-  "cpu_std_dev": 0,
-  "gpu_duration": 0,
-  "gpu_min_duration": 0,
-  "gpu_max_duration": 0,
-  "gpu_std_dev": 0,
-  "npu_duration": 0,
-  "npu_min_duration": 0,
-  "npu_max_duration": 0,
-  "npu_std_dev": 0,
   "in_dim_0": 1,
   "in_dim_1": 32,
   "in_dim_2": 32,
@@ -38,7 +24,5 @@
         "cpu_revision": ""
       }
     }
-  },
-  "npu_error": "timeout or failed",
-  "gpu_error": "timeout or failed"
+  }
 }

--- a/ab/nn/stat/run/tflite/int8/img-classification_cifar-10_acc_unq-ea2d2e370a93b7097fe37b0dada88430/android_STK-L21.json
+++ b/ab/nn/stat/run/tflite/int8/img-classification_cifar-10_acc_unq-ea2d2e370a93b7097fe37b0dada88430/android_STK-L21.json
@@ -2,23 +2,9 @@
   "model_name": "unq-ea2d2e370a93b7097fe37b0dada88430",
   "device_type": "STK-L21",
   "os_version": "10 | HUAWEISTK-L21",
-  "valid": true,
+  "valid": false,
   "emulator": false,
   "iterations": 20,
-  "duration": 0,
-  "unit": "Failed",
-  "cpu_duration": 0,
-  "cpu_min_duration": 0,
-  "cpu_max_duration": 0,
-  "cpu_std_dev": 0,
-  "gpu_duration": 0,
-  "gpu_min_duration": 0,
-  "gpu_max_duration": 0,
-  "gpu_std_dev": 0,
-  "npu_duration": 0,
-  "npu_min_duration": 0,
-  "npu_max_duration": 0,
-  "npu_std_dev": 0,
   "in_dim_0": 1,
   "in_dim_1": 28,
   "in_dim_2": 28,
@@ -38,7 +24,5 @@
         "cpu_revision": ""
       }
     }
-  },
-  "npu_error": "timeout or failed",
-  "gpu_error": "timeout or failed"
+  }
 }

--- a/ab/nn/stat/run/tflite/int8/img-classification_cifar-10_acc_unq-ebf99f2b6fa529f179b1c8907540e675/android_STK-L21.json
+++ b/ab/nn/stat/run/tflite/int8/img-classification_cifar-10_acc_unq-ebf99f2b6fa529f179b1c8907540e675/android_STK-L21.json
@@ -2,23 +2,9 @@
   "model_name": "unq-ebf99f2b6fa529f179b1c8907540e675",
   "device_type": "STK-L21",
   "os_version": "10 | HUAWEISTK-L21",
-  "valid": true,
+  "valid": false,
   "emulator": false,
   "iterations": 20,
-  "duration": 0,
-  "unit": "Failed",
-  "cpu_duration": 0,
-  "cpu_min_duration": 0,
-  "cpu_max_duration": 0,
-  "cpu_std_dev": 0,
-  "gpu_duration": 0,
-  "gpu_min_duration": 0,
-  "gpu_max_duration": 0,
-  "gpu_std_dev": 0,
-  "npu_duration": 0,
-  "npu_min_duration": 0,
-  "npu_max_duration": 0,
-  "npu_std_dev": 0,
   "in_dim_0": 1,
   "in_dim_1": 30,
   "in_dim_2": 30,
@@ -38,7 +24,5 @@
         "cpu_revision": ""
       }
     }
-  },
-  "npu_error": "timeout or failed",
-  "gpu_error": "timeout or failed"
+  }
 }

--- a/ab/nn/stat/run/tflite/int8/img-classification_cifar-10_acc_unq-ec47f92c22dc21e4b4c00c93503264d0/android_STK-L21.json
+++ b/ab/nn/stat/run/tflite/int8/img-classification_cifar-10_acc_unq-ec47f92c22dc21e4b4c00c93503264d0/android_STK-L21.json
@@ -2,23 +2,9 @@
   "model_name": "unq-ec47f92c22dc21e4b4c00c93503264d0",
   "device_type": "STK-L21",
   "os_version": "10 | HUAWEISTK-L21",
-  "valid": true,
+  "valid": false,
   "emulator": false,
   "iterations": 20,
-  "duration": 0,
-  "unit": "Failed",
-  "cpu_duration": 0,
-  "cpu_min_duration": 0,
-  "cpu_max_duration": 0,
-  "cpu_std_dev": 0,
-  "gpu_duration": 0,
-  "gpu_min_duration": 0,
-  "gpu_max_duration": 0,
-  "gpu_std_dev": 0,
-  "npu_duration": 0,
-  "npu_min_duration": 0,
-  "npu_max_duration": 0,
-  "npu_std_dev": 0,
   "in_dim_0": 1,
   "in_dim_1": 32,
   "in_dim_2": 32,
@@ -38,7 +24,5 @@
         "cpu_revision": ""
       }
     }
-  },
-  "npu_error": "timeout or failed",
-  "gpu_error": "timeout or failed"
+  }
 }

--- a/ab/nn/stat/run/tflite/int8/img-classification_cifar-10_acc_unq-ecad43cb32155d3235c9b87cba581811/android_STK-L21.json
+++ b/ab/nn/stat/run/tflite/int8/img-classification_cifar-10_acc_unq-ecad43cb32155d3235c9b87cba581811/android_STK-L21.json
@@ -2,23 +2,9 @@
   "model_name": "unq-ecad43cb32155d3235c9b87cba581811",
   "device_type": "STK-L21",
   "os_version": "10 | HUAWEISTK-L21",
-  "valid": true,
+  "valid": false,
   "emulator": false,
   "iterations": 20,
-  "duration": 0,
-  "unit": "Failed",
-  "cpu_duration": 0,
-  "cpu_min_duration": 0,
-  "cpu_max_duration": 0,
-  "cpu_std_dev": 0,
-  "gpu_duration": 0,
-  "gpu_min_duration": 0,
-  "gpu_max_duration": 0,
-  "gpu_std_dev": 0,
-  "npu_duration": 0,
-  "npu_min_duration": 0,
-  "npu_max_duration": 0,
-  "npu_std_dev": 0,
   "in_dim_0": 1,
   "in_dim_1": 64,
   "in_dim_2": 64,
@@ -38,7 +24,5 @@
         "cpu_revision": ""
       }
     }
-  },
-  "npu_error": "timeout or failed",
-  "gpu_error": "timeout or failed"
+  }
 }

--- a/ab/nn/stat/run/tflite/int8/img-classification_cifar-10_acc_unq-ecc8548dee08ffb1ab8cc7bb73ff2e89/android_STK-L21.json
+++ b/ab/nn/stat/run/tflite/int8/img-classification_cifar-10_acc_unq-ecc8548dee08ffb1ab8cc7bb73ff2e89/android_STK-L21.json
@@ -2,23 +2,9 @@
   "model_name": "unq-ecc8548dee08ffb1ab8cc7bb73ff2e89",
   "device_type": "STK-L21",
   "os_version": "10 | HUAWEISTK-L21",
-  "valid": true,
+  "valid": false,
   "emulator": false,
   "iterations": 20,
-  "duration": 0,
-  "unit": "Failed",
-  "cpu_duration": 0,
-  "cpu_min_duration": 0,
-  "cpu_max_duration": 0,
-  "cpu_std_dev": 0,
-  "gpu_duration": 0,
-  "gpu_min_duration": 0,
-  "gpu_max_duration": 0,
-  "gpu_std_dev": 0,
-  "npu_duration": 0,
-  "npu_min_duration": 0,
-  "npu_max_duration": 0,
-  "npu_std_dev": 0,
   "in_dim_0": 1,
   "in_dim_1": 64,
   "in_dim_2": 64,
@@ -38,7 +24,5 @@
         "cpu_revision": ""
       }
     }
-  },
-  "npu_error": "timeout or failed",
-  "gpu_error": "timeout or failed"
+  }
 }

--- a/ab/nn/stat/run/tflite/int8/img-classification_cifar-10_acc_unq-ed4c857aaa7ed54bd6ebd0e234cb9e13/android_STK-L21.json
+++ b/ab/nn/stat/run/tflite/int8/img-classification_cifar-10_acc_unq-ed4c857aaa7ed54bd6ebd0e234cb9e13/android_STK-L21.json
@@ -2,23 +2,9 @@
   "model_name": "unq-ed4c857aaa7ed54bd6ebd0e234cb9e13",
   "device_type": "STK-L21",
   "os_version": "10 | HUAWEISTK-L21",
-  "valid": true,
+  "valid": false,
   "emulator": false,
   "iterations": 20,
-  "duration": 0,
-  "unit": "Failed",
-  "cpu_duration": 0,
-  "cpu_min_duration": 0,
-  "cpu_max_duration": 0,
-  "cpu_std_dev": 0,
-  "gpu_duration": 0,
-  "gpu_min_duration": 0,
-  "gpu_max_duration": 0,
-  "gpu_std_dev": 0,
-  "npu_duration": 0,
-  "npu_min_duration": 0,
-  "npu_max_duration": 0,
-  "npu_std_dev": 0,
   "in_dim_0": 1,
   "in_dim_1": 64,
   "in_dim_2": 64,
@@ -38,7 +24,5 @@
         "cpu_revision": ""
       }
     }
-  },
-  "npu_error": "timeout or failed",
-  "gpu_error": "timeout or failed"
+  }
 }

--- a/ab/nn/stat/run/tflite/int8/img-classification_cifar-10_acc_unq-ed9addff13fd74726eeec33bc160856a/android_STK-L21.json
+++ b/ab/nn/stat/run/tflite/int8/img-classification_cifar-10_acc_unq-ed9addff13fd74726eeec33bc160856a/android_STK-L21.json
@@ -2,23 +2,9 @@
   "model_name": "unq-ed9addff13fd74726eeec33bc160856a",
   "device_type": "STK-L21",
   "os_version": "10 | HUAWEISTK-L21",
-  "valid": true,
+  "valid": false,
   "emulator": false,
   "iterations": 20,
-  "duration": 0,
-  "unit": "Failed",
-  "cpu_duration": 0,
-  "cpu_min_duration": 0,
-  "cpu_max_duration": 0,
-  "cpu_std_dev": 0,
-  "gpu_duration": 0,
-  "gpu_min_duration": 0,
-  "gpu_max_duration": 0,
-  "gpu_std_dev": 0,
-  "npu_duration": 0,
-  "npu_min_duration": 0,
-  "npu_max_duration": 0,
-  "npu_std_dev": 0,
   "in_dim_0": 1,
   "in_dim_1": 31,
   "in_dim_2": 31,
@@ -38,7 +24,5 @@
         "cpu_revision": ""
       }
     }
-  },
-  "npu_error": "timeout or failed",
-  "gpu_error": "timeout or failed"
+  }
 }

--- a/ab/nn/stat/run/tflite/int8/img-classification_cifar-10_acc_unq-eef1ae6ae969e09d73a29589bcc0d12d/android_STK-L21.json
+++ b/ab/nn/stat/run/tflite/int8/img-classification_cifar-10_acc_unq-eef1ae6ae969e09d73a29589bcc0d12d/android_STK-L21.json
@@ -2,23 +2,9 @@
   "model_name": "unq-eef1ae6ae969e09d73a29589bcc0d12d",
   "device_type": "STK-L21",
   "os_version": "10 | HUAWEISTK-L21",
-  "valid": true,
+  "valid": false,
   "emulator": false,
   "iterations": 20,
-  "duration": 0,
-  "unit": "Failed",
-  "cpu_duration": 0,
-  "cpu_min_duration": 0,
-  "cpu_max_duration": 0,
-  "cpu_std_dev": 0,
-  "gpu_duration": 0,
-  "gpu_min_duration": 0,
-  "gpu_max_duration": 0,
-  "gpu_std_dev": 0,
-  "npu_duration": 0,
-  "npu_min_duration": 0,
-  "npu_max_duration": 0,
-  "npu_std_dev": 0,
   "in_dim_0": 1,
   "in_dim_1": 64,
   "in_dim_2": 64,
@@ -38,7 +24,5 @@
         "cpu_revision": ""
       }
     }
-  },
-  "npu_error": "timeout or failed",
-  "gpu_error": "timeout or failed"
+  }
 }

--- a/ab/nn/stat/run/tflite/int8/img-classification_cifar-10_acc_unq-ef3f42e4c47f693dd8dcbcddca682295/android_STK-L21.json
+++ b/ab/nn/stat/run/tflite/int8/img-classification_cifar-10_acc_unq-ef3f42e4c47f693dd8dcbcddca682295/android_STK-L21.json
@@ -2,23 +2,9 @@
   "model_name": "unq-ef3f42e4c47f693dd8dcbcddca682295",
   "device_type": "STK-L21",
   "os_version": "10 | HUAWEISTK-L21",
-  "valid": true,
+  "valid": false,
   "emulator": false,
   "iterations": 20,
-  "duration": 0,
-  "unit": "Failed",
-  "cpu_duration": 0,
-  "cpu_min_duration": 0,
-  "cpu_max_duration": 0,
-  "cpu_std_dev": 0,
-  "gpu_duration": 0,
-  "gpu_min_duration": 0,
-  "gpu_max_duration": 0,
-  "gpu_std_dev": 0,
-  "npu_duration": 0,
-  "npu_min_duration": 0,
-  "npu_max_duration": 0,
-  "npu_std_dev": 0,
   "in_dim_0": 1,
   "in_dim_1": 128,
   "in_dim_2": 128,
@@ -38,7 +24,5 @@
         "cpu_revision": ""
       }
     }
-  },
-  "npu_error": "timeout or failed",
-  "gpu_error": "timeout or failed"
+  }
 }

--- a/ab/nn/stat/run/tflite/int8/img-classification_cifar-10_acc_unq-f06c45546807e328c053aa06ab41b122/android_STK-L21.json
+++ b/ab/nn/stat/run/tflite/int8/img-classification_cifar-10_acc_unq-f06c45546807e328c053aa06ab41b122/android_STK-L21.json
@@ -2,23 +2,9 @@
   "model_name": "unq-f06c45546807e328c053aa06ab41b122",
   "device_type": "STK-L21",
   "os_version": "10 | HUAWEISTK-L21",
-  "valid": true,
+  "valid": false,
   "emulator": false,
   "iterations": 20,
-  "duration": 0,
-  "unit": "Failed",
-  "cpu_duration": 0,
-  "cpu_min_duration": 0,
-  "cpu_max_duration": 0,
-  "cpu_std_dev": 0,
-  "gpu_duration": 0,
-  "gpu_min_duration": 0,
-  "gpu_max_duration": 0,
-  "gpu_std_dev": 0,
-  "npu_duration": 0,
-  "npu_min_duration": 0,
-  "npu_max_duration": 0,
-  "npu_std_dev": 0,
   "in_dim_0": 1,
   "in_dim_1": 32,
   "in_dim_2": 32,
@@ -38,7 +24,5 @@
         "cpu_revision": ""
       }
     }
-  },
-  "npu_error": "timeout or failed",
-  "gpu_error": "timeout or failed"
+  }
 }

--- a/ab/nn/stat/run/tflite/int8/img-classification_cifar-10_acc_unq-f0c6572e1066b3fdae37750b6cb8fdbc/android_STK-L21.json
+++ b/ab/nn/stat/run/tflite/int8/img-classification_cifar-10_acc_unq-f0c6572e1066b3fdae37750b6cb8fdbc/android_STK-L21.json
@@ -2,23 +2,9 @@
   "model_name": "unq-f0c6572e1066b3fdae37750b6cb8fdbc",
   "device_type": "STK-L21",
   "os_version": "10 | HUAWEISTK-L21",
-  "valid": true,
+  "valid": false,
   "emulator": false,
   "iterations": 20,
-  "duration": 0,
-  "unit": "Failed",
-  "cpu_duration": 0,
-  "cpu_min_duration": 0,
-  "cpu_max_duration": 0,
-  "cpu_std_dev": 0,
-  "gpu_duration": 0,
-  "gpu_min_duration": 0,
-  "gpu_max_duration": 0,
-  "gpu_std_dev": 0,
-  "npu_duration": 0,
-  "npu_min_duration": 0,
-  "npu_max_duration": 0,
-  "npu_std_dev": 0,
   "in_dim_0": 1,
   "in_dim_1": 64,
   "in_dim_2": 64,
@@ -38,7 +24,5 @@
         "cpu_revision": ""
       }
     }
-  },
-  "npu_error": "timeout or failed",
-  "gpu_error": "timeout or failed"
+  }
 }

--- a/ab/nn/stat/run/tflite/int8/img-classification_cifar-10_acc_unq-f0ecd8ad758261d3a40b41d1c276cab9/android_STK-L21.json
+++ b/ab/nn/stat/run/tflite/int8/img-classification_cifar-10_acc_unq-f0ecd8ad758261d3a40b41d1c276cab9/android_STK-L21.json
@@ -2,23 +2,9 @@
   "model_name": "unq-f0ecd8ad758261d3a40b41d1c276cab9",
   "device_type": "STK-L21",
   "os_version": "10 | HUAWEISTK-L21",
-  "valid": true,
+  "valid": false,
   "emulator": false,
   "iterations": 20,
-  "duration": 0,
-  "unit": "Failed",
-  "cpu_duration": 0,
-  "cpu_min_duration": 0,
-  "cpu_max_duration": 0,
-  "cpu_std_dev": 0,
-  "gpu_duration": 0,
-  "gpu_min_duration": 0,
-  "gpu_max_duration": 0,
-  "gpu_std_dev": 0,
-  "npu_duration": 0,
-  "npu_min_duration": 0,
-  "npu_max_duration": 0,
-  "npu_std_dev": 0,
   "in_dim_0": 1,
   "in_dim_1": 32,
   "in_dim_2": 32,
@@ -38,7 +24,5 @@
         "cpu_revision": ""
       }
     }
-  },
-  "npu_error": "timeout or failed",
-  "gpu_error": "timeout or failed"
+  }
 }

--- a/ab/nn/stat/run/tflite/int8/img-classification_cifar-10_acc_unq-f155edbe6b59e283d67928708892fe22/android_STK-L21.json
+++ b/ab/nn/stat/run/tflite/int8/img-classification_cifar-10_acc_unq-f155edbe6b59e283d67928708892fe22/android_STK-L21.json
@@ -2,23 +2,9 @@
   "model_name": "unq-f155edbe6b59e283d67928708892fe22",
   "device_type": "STK-L21",
   "os_version": "10 | HUAWEISTK-L21",
-  "valid": true,
+  "valid": false,
   "emulator": false,
   "iterations": 20,
-  "duration": 0,
-  "unit": "Failed",
-  "cpu_duration": 0,
-  "cpu_min_duration": 0,
-  "cpu_max_duration": 0,
-  "cpu_std_dev": 0,
-  "gpu_duration": 0,
-  "gpu_min_duration": 0,
-  "gpu_max_duration": 0,
-  "gpu_std_dev": 0,
-  "npu_duration": 0,
-  "npu_min_duration": 0,
-  "npu_max_duration": 0,
-  "npu_std_dev": 0,
   "in_dim_0": 1,
   "in_dim_1": 128,
   "in_dim_2": 128,
@@ -38,7 +24,5 @@
         "cpu_revision": ""
       }
     }
-  },
-  "npu_error": "timeout or failed",
-  "gpu_error": "timeout or failed"
+  }
 }

--- a/ab/nn/stat/run/tflite/int8/img-classification_cifar-10_acc_unq-f18ee05bf0bfa1a7fb5f3c01098681b4/android_STK-L21.json
+++ b/ab/nn/stat/run/tflite/int8/img-classification_cifar-10_acc_unq-f18ee05bf0bfa1a7fb5f3c01098681b4/android_STK-L21.json
@@ -2,23 +2,9 @@
   "model_name": "unq-f18ee05bf0bfa1a7fb5f3c01098681b4",
   "device_type": "STK-L21",
   "os_version": "10 | HUAWEISTK-L21",
-  "valid": true,
+  "valid": false,
   "emulator": false,
   "iterations": 20,
-  "duration": 0,
-  "unit": "Failed",
-  "cpu_duration": 0,
-  "cpu_min_duration": 0,
-  "cpu_max_duration": 0,
-  "cpu_std_dev": 0,
-  "gpu_duration": 0,
-  "gpu_min_duration": 0,
-  "gpu_max_duration": 0,
-  "gpu_std_dev": 0,
-  "npu_duration": 0,
-  "npu_min_duration": 0,
-  "npu_max_duration": 0,
-  "npu_std_dev": 0,
   "in_dim_0": 1,
   "in_dim_1": 64,
   "in_dim_2": 64,
@@ -38,7 +24,5 @@
         "cpu_revision": ""
       }
     }
-  },
-  "npu_error": "timeout or failed",
-  "gpu_error": "timeout or failed"
+  }
 }

--- a/ab/nn/stat/run/tflite/int8/img-classification_cifar-10_acc_unq-f1b81d27a39d43bdce8da6c45c3b9259/android_STK-L21.json
+++ b/ab/nn/stat/run/tflite/int8/img-classification_cifar-10_acc_unq-f1b81d27a39d43bdce8da6c45c3b9259/android_STK-L21.json
@@ -2,23 +2,9 @@
   "model_name": "unq-f1b81d27a39d43bdce8da6c45c3b9259",
   "device_type": "STK-L21",
   "os_version": "10 | HUAWEISTK-L21",
-  "valid": true,
+  "valid": false,
   "emulator": false,
   "iterations": 20,
-  "duration": 0,
-  "unit": "Failed",
-  "cpu_duration": 0,
-  "cpu_min_duration": 0,
-  "cpu_max_duration": 0,
-  "cpu_std_dev": 0,
-  "gpu_duration": 0,
-  "gpu_min_duration": 0,
-  "gpu_max_duration": 0,
-  "gpu_std_dev": 0,
-  "npu_duration": 0,
-  "npu_min_duration": 0,
-  "npu_max_duration": 0,
-  "npu_std_dev": 0,
   "in_dim_0": 1,
   "in_dim_1": 32,
   "in_dim_2": 32,
@@ -38,7 +24,5 @@
         "cpu_revision": ""
       }
     }
-  },
-  "npu_error": "timeout or failed",
-  "gpu_error": "timeout or failed"
+  }
 }

--- a/ab/nn/stat/run/tflite/int8/img-classification_cifar-10_acc_unq-f209e0eb5446c5ea371996400170a99c/android_STK-L21.json
+++ b/ab/nn/stat/run/tflite/int8/img-classification_cifar-10_acc_unq-f209e0eb5446c5ea371996400170a99c/android_STK-L21.json
@@ -2,23 +2,9 @@
   "model_name": "unq-f209e0eb5446c5ea371996400170a99c",
   "device_type": "STK-L21",
   "os_version": "10 | HUAWEISTK-L21",
-  "valid": true,
+  "valid": false,
   "emulator": false,
   "iterations": 20,
-  "duration": 0,
-  "unit": "Failed",
-  "cpu_duration": 0,
-  "cpu_min_duration": 0,
-  "cpu_max_duration": 0,
-  "cpu_std_dev": 0,
-  "gpu_duration": 0,
-  "gpu_min_duration": 0,
-  "gpu_max_duration": 0,
-  "gpu_std_dev": 0,
-  "npu_duration": 0,
-  "npu_min_duration": 0,
-  "npu_max_duration": 0,
-  "npu_std_dev": 0,
   "in_dim_0": 1,
   "in_dim_1": 64,
   "in_dim_2": 64,
@@ -38,7 +24,5 @@
         "cpu_revision": ""
       }
     }
-  },
-  "npu_error": "timeout or failed",
-  "gpu_error": "timeout or failed"
+  }
 }

--- a/ab/nn/stat/run/tflite/int8/img-classification_cifar-10_acc_unq-f20ed3d398867a319ffa09df1576b0f3/android_STK-L21.json
+++ b/ab/nn/stat/run/tflite/int8/img-classification_cifar-10_acc_unq-f20ed3d398867a319ffa09df1576b0f3/android_STK-L21.json
@@ -2,23 +2,9 @@
   "model_name": "unq-f20ed3d398867a319ffa09df1576b0f3",
   "device_type": "STK-L21",
   "os_version": "10 | HUAWEISTK-L21",
-  "valid": true,
+  "valid": false,
   "emulator": false,
   "iterations": 20,
-  "duration": 0,
-  "unit": "Failed",
-  "cpu_duration": 0,
-  "cpu_min_duration": 0,
-  "cpu_max_duration": 0,
-  "cpu_std_dev": 0,
-  "gpu_duration": 0,
-  "gpu_min_duration": 0,
-  "gpu_max_duration": 0,
-  "gpu_std_dev": 0,
-  "npu_duration": 0,
-  "npu_min_duration": 0,
-  "npu_max_duration": 0,
-  "npu_std_dev": 0,
   "in_dim_0": 1,
   "in_dim_1": 32,
   "in_dim_2": 32,
@@ -38,7 +24,5 @@
         "cpu_revision": ""
       }
     }
-  },
-  "npu_error": "timeout or failed",
-  "gpu_error": "timeout or failed"
+  }
 }

--- a/ab/nn/stat/run/tflite/int8/img-classification_cifar-10_acc_unq-f217d7c54a672b97cf65b1831eed6ca5/android_STK-L21.json
+++ b/ab/nn/stat/run/tflite/int8/img-classification_cifar-10_acc_unq-f217d7c54a672b97cf65b1831eed6ca5/android_STK-L21.json
@@ -2,23 +2,9 @@
   "model_name": "unq-f217d7c54a672b97cf65b1831eed6ca5",
   "device_type": "STK-L21",
   "os_version": "10 | HUAWEISTK-L21",
-  "valid": true,
+  "valid": false,
   "emulator": false,
   "iterations": 20,
-  "duration": 0,
-  "unit": "Failed",
-  "cpu_duration": 0,
-  "cpu_min_duration": 0,
-  "cpu_max_duration": 0,
-  "cpu_std_dev": 0,
-  "gpu_duration": 0,
-  "gpu_min_duration": 0,
-  "gpu_max_duration": 0,
-  "gpu_std_dev": 0,
-  "npu_duration": 0,
-  "npu_min_duration": 0,
-  "npu_max_duration": 0,
-  "npu_std_dev": 0,
   "in_dim_0": 1,
   "in_dim_1": 32,
   "in_dim_2": 32,
@@ -38,7 +24,5 @@
         "cpu_revision": ""
       }
     }
-  },
-  "npu_error": "timeout or failed",
-  "gpu_error": "timeout or failed"
+  }
 }

--- a/ab/nn/stat/run/tflite/int8/img-classification_cifar-10_acc_unq-f21bf73deec92c93b2e8560484e05d2a/android_STK-L21.json
+++ b/ab/nn/stat/run/tflite/int8/img-classification_cifar-10_acc_unq-f21bf73deec92c93b2e8560484e05d2a/android_STK-L21.json
@@ -2,23 +2,9 @@
   "model_name": "unq-f21bf73deec92c93b2e8560484e05d2a",
   "device_type": "STK-L21",
   "os_version": "10 | HUAWEISTK-L21",
-  "valid": true,
+  "valid": false,
   "emulator": false,
   "iterations": 20,
-  "duration": 0,
-  "unit": "Failed",
-  "cpu_duration": 0,
-  "cpu_min_duration": 0,
-  "cpu_max_duration": 0,
-  "cpu_std_dev": 0,
-  "gpu_duration": 0,
-  "gpu_min_duration": 0,
-  "gpu_max_duration": 0,
-  "gpu_std_dev": 0,
-  "npu_duration": 0,
-  "npu_min_duration": 0,
-  "npu_max_duration": 0,
-  "npu_std_dev": 0,
   "in_dim_0": 1,
   "in_dim_1": 64,
   "in_dim_2": 64,
@@ -38,7 +24,5 @@
         "cpu_revision": ""
       }
     }
-  },
-  "npu_error": "timeout or failed",
-  "gpu_error": "timeout or failed"
+  }
 }


### PR DESCRIPTION
## Summary

Cleanup of 91 TFLite benchmark JSON files for Huawei Y9 Prime (STK-L21) 
where all three backends (CPU, GPU, NPU) failed to produce timing data. 
These were previously stored with `valid: true` and `duration: 0` across 
all fields, which would skew downstream aggregate statistics.

Changes per file:
- `valid` set to `false`
- All duration fields removed (`duration`, `unit`, `cpu_*`, `gpu_*`, `npu_*`)
- Everything else preserved (model_name, device_type, os_version, memory, device_analytics)

## Scope

- **Files modified:** 91 (all `android_STK-L21.json`)
- **Files untouched:** 2234 — rows with at least one successful backend
- **Samsung Z Fold 3:** no affected files

## Verification

Post-cleanup scan:
- Still broken (`valid=true` + all-zero): **0**
- Properly invalid (`valid=false`): 91
- Healthy: 2234