### PR TITLE
Add --pretrained flag support for resuming from best checkpoint

### DIFF
--- a/ab/nn/util/Train.py
+++ b/ab/nn/util/Train.py
@@ -211,10 +211,18 @@ class Train:
         self.device = torch_device()
 
         # Load model
+        # Load model
         model_net = get_attr(nn_module, 'Net')
         self.model_name = nn_module
         self.model = model_net(self.in_shape, out_shape, prm, self.device)
         self.model.to(self.device)
+
+        # Optionally load pretrained weights from a previous run's best
+        # checkpoint. Triggered when prm['pretrained'] == 1, which is set
+        # either by the --pretrained CLI flag (see train.py) or by Optuna's
+        # categorical search over [0, 1] in optuna_objective.
+        if int(prm.get('pretrained', 0)) == 1:
+            load_pretrained_weights(self.model, self.model_name)
 
         # Initialize loss function for tracking
         self.loss_fn = self._get_loss_function()

--- a/ab/nn/util/Util.py
+++ b/ab/nn/util/Util.py
@@ -191,6 +191,9 @@ def save_if_best(model, model_name, current_score, save_pth_weights, save_onnx_w
                  save_path=None):
     """
     Called by the training framework to save weights if performance improves.
+    Also persists the achieved best_score in a sidecar JSON so subsequent
+    runs (when started with --pretrained 1) only overwrite the checkpoint
+    if they exceed it.
     """
     checkpoint_dir = ckpt_dir / model_name.split('.')[-1]
     makedirs(checkpoint_dir, exist_ok=True)
@@ -199,11 +202,77 @@ def save_if_best(model, model_name, current_score, save_pth_weights, save_onnx_w
         setattr(model, 'best_score', current_score)
         best_checkpoint_path = join(checkpoint_dir, "best_model.pth")
         print(f"\n--- New best score: {current_score:.4f} Saving checkpoint... ---")
-        # Use the required function to save the PyTorch weights.
-        if save_pth_weights: export_torch_weights(model, best_checkpoint_path)
+        # Save the PyTorch weights.
+        if save_pth_weights:
+            export_torch_weights(model, best_checkpoint_path)
+            # Persist best_score alongside the .pth so future --pretrained
+            # runs can resume the monotonic-best behaviour.
+            try:
+                meta_path = join(checkpoint_dir, "best_model.json")
+                with open(meta_path, 'w') as f:
+                    json.dump({"best_score": float(current_score)}, f)
+            except Exception as e:
+                print(f"[save_if_best] Failed to write best_score sidecar: {e}")
         if save_onnx_weights:
             t = first_tensor(train_set, num_workers)
             export_model_to_onnx(model, t, join(checkpoint_dir, "best_model.onnx") if save_path else onnx_file)
+
+
+def load_pretrained_weights(model, model_name):
+    """
+    Load weights from the .pth checkpoint that was saved by save_if_best,
+    if one exists for this model. The path mirrors the save convention:
+        <ckpt_dir>/<ModelName>/best_model.pth
+
+    If a sidecar best_model.json is also present, the recorded best_score
+    is restored on the model so save_if_best only overwrites the
+    checkpoint when a strictly better score is reached in the new run.
+
+    Returns True if weights were loaded, False otherwise. Silently skips
+    loading when:
+      - no checkpoint file is present (first training run for this model)
+      - the architecture has changed since the checkpoint was saved
+        (state_dict key/shape mismatch)
+    In both cases training proceeds with the model's current (typically
+    randomly initialised) weights.
+    """
+    checkpoint_dir = ckpt_dir / model_name.split('.')[-1]
+    best_checkpoint_path = join(checkpoint_dir, "best_model.pth")
+
+    if not exists(best_checkpoint_path):
+        print(f"[pretrained] No checkpoint found at {best_checkpoint_path}; "
+              f"training from scratch.")
+        return False
+
+    print(f"[pretrained] Loading weights from {best_checkpoint_path}")
+    try:
+        device = next(model.parameters()).device
+        state_dict = torch.load(
+            best_checkpoint_path, map_location=device, weights_only=True
+        )
+        model.load_state_dict(state_dict, strict=True)
+        print(f"[pretrained] Weights loaded successfully.")
+    except (RuntimeError, KeyError) as e:
+        print(f"[pretrained] Failed to load checkpoint "
+              f"(likely architecture mismatch since save): {e}")
+        print(f"[pretrained] Continuing with current (random) weights.")
+        return False
+
+    # Restore the previous best_score so save_if_best doesn't overwrite
+    # the checkpoint with something worse.
+    meta_path = join(checkpoint_dir, "best_model.json")
+    if exists(meta_path):
+        try:
+            with open(meta_path) as f:
+                meta = json.load(f)
+            if 'best_score' in meta:
+                setattr(model, 'best_score', float(meta['best_score']))
+                print(f"[pretrained] Restored best_score = "
+                      f"{meta['best_score']:.6f} from sidecar.")
+        except Exception as e:
+            print(f"[pretrained] Could not read best_score sidecar: {e}")
+
+    return True
 
 
 def first_tensor(train_set, num_workers=default_num_workers) -> Any:


### PR DESCRIPTION
## Summary
 
The `--pretrained` CLI flag was already parsed by `train.py` and threaded through `optuna_objective`, but no code actually loaded weights from disk. This PR makes the flag functional: when `--pretrained 1` is passed, training resumes from the best checkpoint saved by `save_if_best` instead of starting from random initialization.
  
## What this PR changes
 
**`ab/nn/util/Util.py`**
 
- Adds `load_pretrained_weights(model, model_name)`. Mirrors the path convention used by `save_if_best`:
  ```
  <ckpt_dir>/<ModelName>/best_model.pth
  ```
  Loads the state_dict into the given model. Returns `True` on success, `False` if no checkpoint exists or the architecture has changed since the checkpoint was saved.
- Modifies `save_if_best` to also write a `best_model.json` sidecar containing the achieved best score (~50 bytes). The sidecar lets subsequent `--pretrained` runs restore the previous `best_score` so `save_if_best` only overwrites the checkpoint when a strictly better score is reached. This guarantees monotonic improvement across chained fine-tuning runs.
**`ab/nn/util/Train.py`**
 
- Calls `load_pretrained_weights` from `Train.__init__` immediately after model construction, gated on `int(prm.get('pretrained', 0)) == 1`. Backward-compatible: if a model doesn't declare `'pretrained'` in its `supported_hyperparameters()`, the value defaults to `0` and the loader is skipped.
No changes to `train.py`, the CLI argument parser, or any model file.
 
## Behavior
 
| Scenario | Result |
|---|---|
| No checkpoint exists (first run for this model) | Logs `[pretrained] No checkpoint found ...; training from scratch.` and trains from scratch. |
| Checkpoint exists, architecture unchanged | Loads weights and restores best_score from sidecar. Training continues from that state. |
| Checkpoint exists, architecture changed since save | Catches the RuntimeError, logs the size mismatch, falls back to from-scratch training. No crash. |
| `--pretrained 0` or flag omitted | Loader is skipped entirely. Existing behavior preserved. |
| `--pretrained 1` and model declares `'pretrained'` in `supported_hyperparameters()` | Loader runs. |
 
## How to use it
 
```bash
# Run 1 — train from scratch, save best checkpoint
python -m ab.nn.train -c img-denoising_denoise_psnr_HeavyDenoiseNet \
    -f denoise -e 100 -t 1 --save_pth_weights True
 
# Run 2 — continue from run 1's best checkpoint
python -m ab.nn.train -c img-denoising_denoise_psnr_HeavyDenoiseNet \
    -f denoise -e 100 -t 1 --pretrained 1 --save_pth_weights True
```
 
For a model to opt into pretrained loading, include `'pretrained'` in its `supported_hyperparameters()`:
 
```python
def supported_hyperparameters():
    return {"lr", "pretrained"}
```
 
## Notes on Optuna interaction
 
The `pretrained` parameter in `main()` has three valid values: `1` (always load), `0` (never load), and `None` (default — Optuna decides per trial via `trial.suggest_categorical('pretrained', [0, 1])`).
 
With this patch, the "Optuna decides" mode now produces meaningfully different trials (some load, some don't) instead of the value being a no-op. For deterministic Optuna studies, users should explicitly set `--pretrained 0` or `--pretrained 1`.
 
## Backward compatibility
 
- Existing models that don't declare `'pretrained'` in `supported_hyperparameters()` are unaffected.
- Checkpoints saved by previous versions of `save_if_best` (without the JSON sidecar) load correctly; only the `best_score` restore step is skipped with a graceful info message.
- No breaking changes to `train.py` CLI or any existing function signature.
## Scope
 
This PR loads model weights only. Optimizer state, LR scheduler state, and epoch counter are not persisted across runs. This is intentional: for fine-tuning, restarting the optimizer and scheduler is usually desired (fresh LR warmup, fresh momentum estimates). Full resume is a separate feature that can be added in a follow-up if needed.
 
## Verification
 
All 7 verification steps were run end-to-end on `HeavyDenoiseNet` (41.6M params).
 
### Step 1: Imports resolve
 
```bash
python3 -c "from ab.nn.util.Util import load_pretrained_weights, save_if_best; print('OK')"
```
**Result:** Both functions import cleanly. ✅
 
### Step 2: Train.__init__ calls the loader
 
```bash
grep -n "load_pretrained_weights" ab/nn/util/Train.py
```
**Result:** Exactly one call site in `Train.__init__` after model construction. ✅
 
### Step 3: First run saves checkpoint + sidecar
 
```bash
python -m ab.nn.train -c img-denoising_denoise_psnr_HeavyDenoiseNet \
    -f denoise -e 3 -t 1 --save_pth_weights True -p '{"lr": 1e-4, "batch": 4}'
```
**Result:** Both `out/ckpt/HeavyDenoiseNet/best_model.pth` and `out/ckpt/HeavyDenoiseNet/best_model.json` were created. Sidecar contained `{"best_score": 0.733724}`. ✅
 
### Step 4: Second run loads checkpoint and restores best_score
 
```bash
python -m ab.nn.train -c img-denoising_denoise_psnr_HeavyDenoiseNet \
    -f denoise -e 2 -t 1 --pretrained 1 --save_pth_weights True \
    -p '{"lr": 1e-5, "batch": 4}'
```
**Result:**
```
[pretrained] Loading weights from .../best_model.pth
[pretrained] Weights loaded successfully.
[pretrained] Restored best_score = 0.733724 from sidecar.
epoch 1
  Test Acc: 0.7339
```
Epoch 1 starts at ~0.73, matching the loaded checkpoint — not at ~0.2 of a fresh run. New best (0.7339) correctly triggered a checkpoint update. ✅
 
### Step 5: Missing-checkpoint graceful fallback
 
```bash
rm -rf out/ckpt/HeavyDenoiseNet
python -m ab.nn.train -c img-denoising_denoise_psnr_HeavyDenoiseNet \
    -f denoise -e 1 -t 1 --pretrained 1 -p '{"lr": 1e-4, "batch": 4}'
```
**Result:**
```
[pretrained] No checkpoint found at .../best_model.pth; training from scratch.
```
Training completed normally without crashing. ✅
 
### Step 6: Architecture-mismatch graceful fallback
 
Changed `f0 = 64` → `f0 = 65` in `HeavyDenoiseNet.py`, then ran with `--pretrained 1`:
 
**Result:**
```
[pretrained] Loading weights from .../best_model.pth
[pretrained] Failed to load checkpoint (likely architecture mismatch since save):
    Error(s) in loading state_dict for Net:
    size mismatch for input_block.conv_1.weight:
    copying a param with shape torch.Size([64, 3, 3, 3]) from checkpoint,
    the shape in current model is torch.Size([65, 3, 3, 3]).
[pretrained] Continuing with current (random) weights.
```
Training completed without crashing. Architecture was reverted to `f0 = 64`. ✅
 
### Step 7: Monotonic-best protection
 
Manually set the sidecar to `{"best_score": 0.99}` (higher than achievable in a short run), then ran with `--pretrained 1` and `--save_pth_weights True`:
 
**Result:**
```
[pretrained] Restored best_score = 0.990000 from sidecar.
epoch 1
  Test Acc: 0.7126
```
- No "New best score" message appeared in stdout
- No "Exporting model weights" message appeared
- `best_model.pth` timestamp unchanged before and after the run
- `save_if_best` correctly refused to overwrite (0.7126 < 0.99)
✅
 
### Verification summary
 
| Step | Test | Result |
|---|---|---|
| 1 | Imports resolve | ✅ PASS |
| 2 | `Train.__init__` calls loader | ✅ PASS |
| 3 | First run saves .pth + .json sidecar | ✅ PASS |
| 4 | Second run loads and restores best_score | ✅ PASS |
| 5 | Missing checkpoint → graceful fallback | ✅ PASS |
| 6 | Architecture mismatch → graceful fallback | ✅ PASS |
| 7 | Monotonic-best prevents overwrite when new < old | ✅ PASS |