### PR TITLE
Add train_stat table for per-epoch diagnostics

### DIFF
--- a/ab/nn/util/Const.py
+++ b/ab/nn/util/Const.py
@@ -156,10 +156,15 @@ main_columns_ext = main_columns + ('epoch',)
 code_tables = ('nn', 'transform', 'metric')
 param_tables = ('prm',)
 dependent_tables = code_tables + param_tables
-all_tables = main_tables + dependent_tables
 index_colum = ('task', 'dataset') + dependent_tables
 extra_main_columns = ('duration', 'accuracy')
 nn_code_minhash_table = "nn_minhash" #New
+
+# Training statistics table (define before all_tables)
+train_stat_table = 'train_stat'
+
+# All tables including training stats
+all_tables = main_tables + dependent_tables + (train_stat_table,)
 
 # Mobile analytics (runtime) table
 run_table = 'run'
@@ -176,6 +181,7 @@ stat_run_pt_dir = stat_dir / 'run' / 'pt'
 
 # NN statistics table
 nn_stat_table = 'nn_stat'
+
 HF_NN = 'NN-Dataset'
 tmp_data = "tmp_data"
 STAT_TABLE = "stat"

--- a/ab/nn/util/Train.py
+++ b/ab/nn/util/Train.py
@@ -394,29 +394,36 @@ class Train:
             # Collect current resource usage
             resource_usage = get_current_resource_usage()
             
+            # Create train_stat group with new parameters
+            train_stat_group = {
+                'train_loss': train_loss,
+                'test_loss': test_loss,
+                'train_accuracy': train_accuracy,
+                'gradient_norm': grad_norm,
+                'samples_per_second': samples_per_second,
+                'best_accuracy': self.best_accuracy,
+                'best_epoch': self.best_epoch,
+                'epoch_max': epoch_max,
+                'cpu_count': self.system_info.get('cpu_count'),
+                'cpu_type': self.system_info.get('cpu_type'),
+                'cpu_usage_percent': resource_usage.get('cpu_usage_percent'),
+                'total_ram_kb': self.system_info.get('total_ram_kb'),
+                'occupied_ram_kb': resource_usage.get('occupied_ram_kb'),
+                'ram_usage_percent': resource_usage.get('ram_usage_percent'),
+                'gpu_type': self.system_info.get('gpu_type'),
+                'gpu_memory_kb': get_gpu_memory_kb(),
+                'gpu_total_memory_kb': self.system_info.get('gpu_total_memory_kb'),
+                'occupied_gpu_memory_kb': resource_usage.get('occupied_gpu_memory_kb'),
+                'gpu_memory_usage_percent': resource_usage.get('gpu_memory_usage_percent'),
+            }
+            
             prm = merge_prm(self.prm, {
                                           'uid': uuid4(only_prm),
                                           'duration': duration,
                                           'accuracy': accuracy,
-                                          # Loss metrics
-                                          'train_loss': train_loss,
-                                          'test_loss': test_loss,
-                                          # Accuracy metrics
-                                          'train_accuracy': train_accuracy,
-                                          # Training dynamics
-                                          'gradient_norm': grad_norm,
-                                          # Timing metrics
-                                          'samples_per_second': samples_per_second,
-                                          # Best tracking
-                                          'best_accuracy': self.best_accuracy,
-                                          'best_epoch': self.best_epoch,
+                                          # New: grouped training statistics (only place they appear)
+                                          'train_stat': train_stat_group,
                                       } 
-                                      # System information
-                                      | self.system_info
-                                      # Current resource usage
-                                      | resource_usage
-                                      # GPU memory (if available)
-                                      | ({'gpu_memory_kb': get_gpu_memory_kb()} if get_gpu_memory_kb() is not None else {})
                                       # Multi-metrics implementations
                                       | {f'metric_{k}': v for k, v in all_metric_results.items()})
 

--- a/ab/nn/util/db/Init.py
+++ b/ab/nn/util/db/Init.py
@@ -2,7 +2,7 @@ import sqlite3
 from os import makedirs
 from pathlib import Path
 
-from ab.nn.util.Const import param_tables, db_file, db_dir, main_tables, code_tables, dependent_tables, all_tables, index_colum, run_table, nn_stat_table, tflite_table, prun_table
+from ab.nn.util.Const import param_tables, db_file, db_dir, main_tables, code_tables, dependent_tables, all_tables, index_colum, run_table, nn_stat_table, tflite_table, prun_table, train_stat_table
 from ab.nn.util.db.build_nn_similarity import jaccard_blobs
 
 SQLITE_BUSY_TIMEOUT_MS = 300_000
@@ -75,6 +75,48 @@ def init_db():
     cursor.execute("CREATE INDEX IF NOT EXISTS idx_accuracy_desc ON stat (accuracy DESC)")
     for nm in index_colum:
         cursor.execute(f"CREATE INDEX IF NOT EXISTS idx_{nm} ON stat ({nm})")
+
+    # Create training statistics table
+    # Stores per-epoch training diagnostics linked to the main stat table.
+    cursor.execute(f"""
+    CREATE TABLE IF NOT EXISTS {train_stat_table} (
+        stat_id TEXT PRIMARY KEY,
+
+        train_loss REAL,
+        test_loss REAL,
+        train_accuracy REAL,
+        gradient_norm REAL,
+        samples_per_second REAL,
+        epoch_max INTEGER,
+
+        cpu_count INTEGER,
+        cpu_type TEXT,
+        cpu_usage_percent REAL,
+
+        total_ram_kb REAL,
+        occupied_ram_kb REAL,
+        ram_usage_percent REAL,
+
+        gpu_type TEXT,
+        gpu_memory_kb REAL,
+        gpu_total_memory_kb REAL,
+        occupied_gpu_memory_kb REAL,
+        gpu_memory_usage_percent REAL,
+
+        FOREIGN KEY (stat_id) REFERENCES stat(id) ON DELETE CASCADE
+    )
+    """)
+
+    # Add indexes for training statistics
+    cursor.execute(
+        f"CREATE INDEX IF NOT EXISTS idx_{train_stat_table}_gradient_norm "
+        f"ON {train_stat_table} (gradient_norm);"
+    )
+
+    cursor.execute(
+        f"CREATE INDEX IF NOT EXISTS idx_{train_stat_table}_samples_per_second "
+        f"ON {train_stat_table} (samples_per_second);"
+    )
 
     # Create mobile analytics table (runtime stats)
     cursor.execute(f"""

--- a/ab/nn/util/db/Read.py
+++ b/ab/nn/util/db/Read.py
@@ -790,6 +790,93 @@ def nn_stat_data(
     finally:
         close_conn(conn)
 
+def train_stat_data(
+        task: str | None = None,
+        dataset: str | None = None,
+        metric: str | None = None,
+        nn: str | None = None,
+        epoch: int | None = None,
+        max_rows: int | None = None,
+):
+    """
+    Query per-epoch training diagnostics from train_stat joined with stat.
+
+    Returns experiment metadata from stat together with training diagnostics
+    from train_stat.
+    """
+    params = []
+    filters = []
+
+    if task is not None:
+        filters.append("s.task = ?")
+        params.append(task)
+    if dataset is not None:
+        filters.append("s.dataset = ?")
+        params.append(dataset)
+    if metric is not None:
+        filters.append("s.metric = ?")
+        params.append(metric)
+    if nn is not None:
+        filters.append("s.nn = ?")
+        params.append(nn)
+    if epoch is not None:
+        filters.append("s.epoch = ?")
+        params.append(epoch)
+
+    where_clause = " WHERE " + " AND ".join(filters) if filters else ""
+    limit_clause = " LIMIT " + str(max_rows) if max_rows else ""
+
+    conn, cur = sql_conn()
+    try:
+        cur.execute(
+            f"""
+            SELECT
+                s.id AS stat_id,
+                s.task,
+                s.dataset,
+                s.metric,
+                s.nn,
+                s.epoch,
+                s.transform,
+                s.prm AS prm_id,
+                s.accuracy,
+                s.duration,
+
+                ts.train_loss,
+                ts.test_loss,
+                ts.train_accuracy,
+                ts.gradient_norm,
+                ts.samples_per_second,
+                ts.epoch_max,
+
+                ts.cpu_count,
+                ts.cpu_type,
+                ts.cpu_usage_percent,
+
+                ts.total_ram_kb,
+                ts.occupied_ram_kb,
+                ts.ram_usage_percent,
+
+                ts.gpu_type,
+                ts.gpu_memory_kb,
+                ts.gpu_total_memory_kb,
+                ts.occupied_gpu_memory_kb,
+                ts.gpu_memory_usage_percent
+            FROM stat s
+            JOIN {train_stat_table} ts
+                ON ts.stat_id = s.id
+            {where_clause}
+            ORDER BY s.task, s.dataset, s.metric, s.nn, s.epoch
+            {limit_clause}
+            """,
+            params,
+        )
+
+        rows = cur.fetchall()
+        columns = [c[0] for c in cur.description]
+        return tuple(dict(zip(columns, r)) for r in rows)
+    finally:
+        close_conn(conn)
 
 def supported_transformers() -> list[str]:
     """

--- a/ab/nn/util/db/Write.py
+++ b/ab/nn/util/db/Write.py
@@ -13,7 +13,7 @@ from tqdm import tqdm
 from ab.nn.util.Util import *
 from ab.nn.util.db.Init import init_db, sql_conn, close_conn
 from ab.nn.util.hf.DB_from_HF import db_from_hf
-from ab.nn.util.Const import nn_stat_table, stat_run_tflite_fp32_dir, stat_run_tflite_int8_dir, run_table, tflite_table, prun_table, stat_run_pt_dir
+from ab.nn.util.Const import nn_stat_table, stat_run_tflite_fp32_dir, stat_run_tflite_int8_dir, run_table, tflite_table, prun_table, stat_run_pt_dir, train_stat_table
 from ab.nn.util.db.build_nn_similarity import upsert_minhash, upsert_minhash_batch
 
 
@@ -129,18 +129,80 @@ def populate_prm_table(table_name, cursor, prm, uid):
         )
 
 
+TRAIN_STAT_DB_FIELDS = (
+    'train_loss',
+    'test_loss',
+    'train_accuracy',
+    'gradient_norm',
+    'samples_per_second',
+    'epoch_max',
+
+    'cpu_count',
+    'cpu_type',
+    'cpu_usage_percent',
+
+    'total_ram_kb',
+    'occupied_ram_kb',
+    'ram_usage_percent',
+
+    'gpu_type',
+    'gpu_memory_kb',
+    'gpu_total_memory_kb',
+    'occupied_gpu_memory_kb',
+    'gpu_memory_usage_percent',
+)
+
+
+def save_train_stat(cursor, stat_id: str, train_stat: dict):
+    """
+    Save grouped per-epoch training statistics into train_stat table.
+
+    best_accuracy and best_epoch may exist in JSON, but are intentionally
+    not stored in the train_stat database table.
+    """
+    if not train_stat:
+        return
+
+    columns = ('stat_id',) + TRAIN_STAT_DB_FIELDS
+    placeholders = ', '.join(['?'] * len(columns))
+
+    values = [stat_id] + [train_stat.get(field) for field in TRAIN_STAT_DB_FIELDS]
+
+    cursor.execute(
+        f"""
+        INSERT OR REPLACE INTO {train_stat_table}
+        ({', '.join(columns)})
+        VALUES ({placeholders})
+        """,
+        values,
+    )
+
+
 def save_stat(config_ext: tuple[str, str, str, str, int], prm, cursor):
     # Insert each trial into the database with epoch
+    prm = dict(prm)
+
+    # Extract grouped training diagnostics before prm-table insert
+    train_stat = prm.pop('train_stat', {})
+
     transform = prm['transform']
     uid = prm.pop('uid')
     extra_main_column_values = [prm.pop(nm, None) for nm in extra_main_columns]
+
+    # Only normal hyperparameters go into prm table
     for nm in param_tables:
         populate_prm_table(nm, cursor, prm, uid)
+
     all_values = [transform, uid, *config_ext, *extra_main_column_values]
+    stat_id = uuid4(all_values)
+
     cursor.execute(f"""
     INSERT INTO stat (id, transform, prm, {', '.join(main_columns_ext + extra_main_columns)}) 
     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-    """, (uuid4(all_values), *all_values))
+    """, (stat_id, *all_values))
+
+    # Save train_stat row linked 1:1 to stat.id
+    save_train_stat(cursor, stat_id, train_stat)
 
 
 @_serialized_db_write


### PR DESCRIPTION
## Add Per-Epoch Training Statistics Table

### Overview

This PR adds a new `train_stat` database table to store per-epoch training diagnostics in a structured and queryable format. The table is linked one-to-one with the existing `stat` table using `stat_id`, avoiding duplication of existing experiment metadata such as task, dataset, metric, model, epoch, transform, and parameter UID.

The JSON output has also been updated so that new training diagnostics are grouped under a separate `train_stat` object, keeping the exported per-epoch statistics more organized.

A new read helper has been added to query these diagnostics directly for downstream analysis and prompt-based evaluation of how the added parameters improve the training pipeline.

### Changes by File

#### 1. `Const.py`

Added the new table constant:

```python
train_stat_table = 'train_stat'
```

Updated `all_tables` to include the new table:

```python
all_tables = main_tables + dependent_tables + (train_stat_table,)
```

This ensures `train_stat` is included in database reset/drop handling.

#### 2. `Train.py`

Added a grouped `train_stat` dictionary during each training epoch.

The JSON output now includes a nested `train_stat` object containing per-epoch diagnostics such as:

```text
train_loss
test_loss
train_accuracy
gradient_norm
samples_per_second
epoch_max

cpu_count
cpu_type
cpu_usage_percent

total_ram_kb
occupied_ram_kb
ram_usage_percent

gpu_type
gpu_memory_kb
gpu_total_memory_kb
occupied_gpu_memory_kb
gpu_memory_usage_percent

best_accuracy
best_epoch
```

`best_accuracy` and `best_epoch` are included in the JSON `train_stat` group for reference, but they are intentionally not stored in the database `train_stat` table.

Existing top-level fields such as `uid`, `duration`, `accuracy`, hyperparameters, `transform`, and `metric_*` values remain unchanged.

#### 3. `Init.py`

Added schema creation for the new `train_stat` table.

The table uses:

```text
stat_id TEXT PRIMARY KEY
```

where `stat_id` is also a foreign key referencing:

```text
stat(id)
```

This creates a one-to-one relationship:

```text
stat.id  ←→  train_stat.stat_id
```

The table stores the following database fields:

```text
train_loss
test_loss
train_accuracy
gradient_norm
samples_per_second
epoch_max

cpu_count
cpu_type
cpu_usage_percent

total_ram_kb
occupied_ram_kb
ram_usage_percent

gpu_type
gpu_memory_kb
gpu_total_memory_kb
occupied_gpu_memory_kb
gpu_memory_usage_percent
```

The table intentionally does not repeat columns already available in `stat`, such as task, dataset, metric, model, epoch, transform, parameter UID, accuracy, or duration.

Added indexes for:

```text
gradient_norm
samples_per_second
```

#### 4. `Write.py`

Updated the database write flow to support the grouped `train_stat` JSON structure.

Main changes:

```text
- Extracts the nested train_stat dictionary before writing hyperparameters to prm.
- Prevents the train_stat dictionary from being inserted into the generic prm table.
- Generates stat_id before inserting the main stat row.
- Inserts the main experiment row into stat.
- Inserts the grouped diagnostics into train_stat using the same stat_id.
```

Added `TRAIN_STAT_DB_FIELDS` to define which fields from the JSON `train_stat` group are stored in the database.

Added `save_train_stat()` to persist the training diagnostics into the new table.

`best_accuracy` and `best_epoch` may exist in the JSON group, but they are intentionally excluded from the database insert.

#### 5. `Read.py`

Added a new helper function:

```python
train_stat_data()
```

This function joins `train_stat` with the existing `stat` table using:

```text
train_stat.stat_id = stat.id
```

It returns experiment metadata from `stat` together with the new per-epoch diagnostics from `train_stat`.

This provides direct access to the new parameters for analysis without modifying existing read functions such as `data()` or changing the existing API behavior.

Example usage:

```python
from ab.nn.util.db.Read import train_stat_data

rows = train_stat_data(
    task="img-classification",
    dataset="cifar-10",
    metric="acc",
    nn="ComplexNet",
)
```

### Database Relationship

```text
stat table
├── id PRIMARY KEY
├── task
├── dataset
├── metric
├── nn
├── epoch
├── transform
├── prm
├── accuracy
└── duration

train_stat table
├── stat_id PRIMARY KEY, FOREIGN KEY → stat.id
├── train_loss
├── test_loss
├── train_accuracy
├── gradient_norm
├── samples_per_second
├── epoch_max
├── cpu_count
├── cpu_type
├── cpu_usage_percent
├── total_ram_kb
├── occupied_ram_kb
├── ram_usage_percent
├── gpu_type
├── gpu_memory_kb
├── gpu_total_memory_kb
├── occupied_gpu_memory_kb
└── gpu_memory_usage_percent
```

### Validation

Tested with:

```bash
python -m ab.nn.train -c img-classification_cifar-10_acc_ComplexNet -f complex -p "{\"lr\": 0.017, \"momentum\": 0.022, \"batch\": 32}" -e 20 -t -1 --epoch_limit_minutes 300
```

Verified that:

```text
- Per-epoch JSON files are created with grouped train_stat data.
- The stat table is populated normally.
- The train_stat table is created with stat_id as the primary/foreign key.
- New diagnostic metrics are inserted into train_stat.
- best_accuracy and best_epoch remain only in JSON and are not stored in the train_stat table.
- train_stat_data() returns the joined stat + train_stat fields for analysis.
```
