### PR TITLE
fix: populate train_stat table from JSON on DB init"

### DIFF
--- a/ab/nn/util/db/Write.py
+++ b/ab/nn/util/db/Write.py
@@ -196,7 +196,7 @@ def save_stat(config_ext: tuple[str, str, str, str, int], prm, cursor):
     stat_id = uuid4(all_values)
 
     cursor.execute(f"""
-    INSERT INTO stat (id, transform, prm, {', '.join(main_columns_ext + extra_main_columns)})
+    INSERT OR IGNORE INTO stat (id, transform, prm, {', '.join(main_columns_ext + extra_main_columns)})
     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     """, (stat_id, *all_values))
 
@@ -237,7 +237,10 @@ def json_train_to_db():
 
                         if trial['transform']:
                             populate_code_table('transform', cursor, name=trial['transform'])
+                        extracted_train_stat = trial.get('train_stat') if isinstance(trial.get('train_stat'), dict) else {}
                         trial = {k: v for k, v in trial.items() if not isinstance(v, (dict, list))}
+                        if extracted_train_stat:
+                            trial['train_stat'] = extracted_train_stat
 
                         save_stat(sub_config + (epoch,), trial, cursor)
             except Exception as e:


### PR DESCRIPTION
### Fix train_stat population from JSON stat files
### Purpose
The train_stat database table was always empty despite training runs saving diagnostic statistics (loss, gradient norm, GPU usage, etc.) to JSON files. This blocked any downstream use of these statistics — including prompting them through nn-gpt. The root cause was in json_train_to_db(), which is called by init_population() when the DB is first created from JSON files.

### Changes in ab/nn/util/db/Write.py

1. Fix 1: json_train_to_db(): preserve train_stat before the nested-dict filter

json_train_to_db() reads each epoch JSON file and filters out all nested dict/list values from trial before passing it to save_stat(). Since train_stat is itself a dict, it was silently dropped by this filter every time. save_stat() then called save_train_stat() with an empty dict, which hit the early-return guard (if not train_stat: return) and wrote nothing to the table.
Fix: extract train_stat from trial before the filter runs, then restore it afterwards so save_stat() receives it intact.

2. Fix 2: save_stat(): INSERT INTO stat → INSERT OR IGNORE INTO stat

When json_train_to_db() processes JSON files for stat rows that already exist in the DB, the plain INSERT raised an IntegrityError on the duplicate stat_id. This was caught by the outer except block, which skipped the entire trial — including the save_train_stat() call that follows the INSERT. Changing to INSERT OR IGNORE silently skips the duplicate stat insert but allows execution to continue to save_train_stat(), which uses INSERT OR REPLACE and correctly writes the missing train_stat row.
This has no effect on live training runs — each new epoch produces a unique stat_id so the INSERT never collides in practice.

### Result
After deleting the DB and letting init_population() rebuild it, train_stat rows are correctly populated alongside every stat row. DB_Read.train_stat_data() returns data, enabling train_stat parameters to be read directly from the DB and prompted through nn-gpt.
