### PR TITLE
Migrate ai_edge_torch → litert_torch in upload2HF

### DIFF
--- a/ab/nn/imp/upload2HF.py
+++ b/ab/nn/imp/upload2HF.py
@@ -289,10 +289,10 @@ def mixed_precision_converter_flags(target_h: int, data_root: Path) -> dict:
     }
 
 def export_fp32_reference(model, dummy_input, ref_path):
-    import ai_edge_torch
+    import litert_torch
     print(f"   [BASELINE] FP32 reference not found, exporting for size comparison...")
     t0 = time.perf_counter()
-    ai_edge_torch.convert(model, dummy_input).export(str(ref_path))
+    litert_torch.convert(model, dummy_input).export(str(ref_path))
     verify_tflite(ref_path)
     print(f"   Baseline size:          {file_size_kib(ref_path):.2f} KiB")
     print(f"   Baseline export time:   {(time.perf_counter() - t0) * 1000:.2f} ms")
@@ -330,7 +330,7 @@ def main():
         return
 
     # --- IMPORT TFLITE ONLY WHEN NEEDED ---
-    import ai_edge_torch
+    import litert_torch
     import tensorflow as tf
 
     if args.push_hf: create_repo(TARGET_REPO, repo_type="model", exist_ok=True)
@@ -413,7 +413,7 @@ def main():
                 acc_fp = run_convert_and_eval(
                     "FP32 Conversion",
                     "FP32",
-                    lambda: ai_edge_torch.convert(model, dummy_input).export(str(fp32_p)),
+                    lambda: litert_torch.convert(model, dummy_input).export(str(fp32_p)),
                     fp32_p,
                     data_root,
                 )
@@ -430,7 +430,7 @@ def main():
                 acc_fp16 = run_convert_and_eval(
                     "FP16 Conversion",
                     "FP16",
-                    lambda: ai_edge_torch.convert(
+                    lambda: litert_torch.convert(
                         model, dummy_input,
                         _ai_edge_converter_flags={
                             'optimizations': [tf.lite.Optimize.DEFAULT],
@@ -453,7 +453,7 @@ def main():
                 acc_mixed = run_convert_and_eval(
                     "Mixed Precision Conversion",
                     "MIXED",
-                    lambda: ai_edge_torch.convert(
+                    lambda: litert_torch.convert(
                         model, dummy_input,
                         _ai_edge_converter_flags=mixed_precision_converter_flags(target_h, data_root),
                     ).export(str(mixed_p)),
@@ -473,7 +473,7 @@ def main():
                 acc_int = run_convert_and_eval(
                     "Static INT8 Conversion",
                     "STATIC",
-                    lambda: ai_edge_torch.convert(
+                    lambda: litert_torch.convert(
                         model, dummy_input,
                         _ai_edge_converter_flags={
                             'optimizations': [tf.lite.Optimize.DEFAULT],
@@ -499,7 +499,7 @@ def main():
                 acc_dynamic = run_convert_and_eval(
                     "Dynamic INT8 Conversion",
                     "DYNAMIC",
-                    lambda: ai_edge_torch.convert(
+                    lambda: litert_torch.convert(
                         model, dummy_input,
                         _ai_edge_converter_flags={'optimizations': [tf.lite.Optimize.DEFAULT]},
                     ).export(str(dynamic_p)),

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,11 @@
 torch>=2.4,<2.9
 diffusers==0.33.0
 #
-# NOTE (Windows): `ai-edge-torch` currently pulls `ai-edge-tensorflow`/`tf-nightly`/
+# NOTE (Windows): `litert-torch` (successor to `ai-edge-torch`) pulls `tf-nightly`/
 # `ai-edge-litert` which don't ship Windows wheels, so pip can't resolve them.
 # The codebase already falls back to `tf.lite.Interpreter` when LiteRT isn't present.
-# Install `ai-edge-torch` only on non-Windows platforms.
-ai-edge-torch; platform_system != "Windows"
+# Install `litert-torch` only on non-Windows platforms.
+litert-torch; platform_system != "Windows"
 torchvision>=0.21,<0.24
 transformers
 bitsandbytes


### PR DESCRIPTION
Migrates `ab/nn/imp/upload2HF.py` from the deprecated `ai_edge_torch` package to its
renamed successor `litert_torch`.

## Changes
`ab/nn/imp/upload2HF.py` — 8 call sites across 1 file:
- **Imports:** in `export_fp32_reference()` and in `main()` → `litert_torch`
- **All 5 conversion paths** — FP32, FP16, mixed precision, static INT8, dynamic INT8 —
  `ai_edge_torch.convert(...)` → `litert_torch.convert(...)`

The `_ai_edge_converter_flags=` keyword argument is intentionally left unchanged —
`litert_torch` keeps that parameter name for backward compatibility.

No logic, control flow, quantization configs, or HuggingFace upload behavior was touched.

## Verification
Ran the full pipeline on **AlexNet** with `litert_torch 0.8.0` — all 5 quantization modes
(FP32 / FP16 / mixed / static INT8 / dynamic INT8) converted to TFLite and passed the
CIFAR-10 accuracy evaluation. No push to HuggingFace was performed (`--push-hf` off).
